### PR TITLE
Gestión municipal: login diferido, panel admin de solicitudes y flujo ciudadano

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,30 +6,35 @@
 
 ## 📍 Estructura de Ramas
 
-El proyecto usa **Git Flow** con ramas por módulo funcional. Cada módulo tiene su rama dedicada que integra en `develop` (rama principal de integración).
+El proyecto usa un flujo simplificado con **dos ramas permanentes** y **ramas temporales** por tarea:
 
 ```
-master (producción)
-├── develop (integración principal)
-│   ├── feature/frontend
-│   ├── feature/backend
-│   ├── feature/auth
-│   ├── feature/marketplace
-│   ├── feature/dashboard
-│   └── feature/devops
+master (main) ── solo versiones completas / releases
+└── develop ── rama de trabajo e integración principal
+    ├── <rama-temporal-tarea-1>   (se crea desde develop, se borra al integrar)
+    ├── <rama-temporal-tarea-2>
+    └── ...
 ```
+
+- **`master` (o `main`):** solo recibe **versiones completas** (releases), como el estado actual. No se trabaja directamente sobre ella.
+- **`develop`:** rama principal de trabajo e integración. Todo lo del día a día vive aquí.
+- **Ramas temporales:** se crean **desde `develop`** cada vez que se trabaja una tarea y **se borran al integrarse** (commit/merge a `develop`). No hay ramas fijas por persona ni por módulo.
+
+> Cambio respecto al modelo anterior: ya **no existen** ramas permanentes por módulo (`feature/frontend`, `feature/backend`, etc.). Fueron eliminadas; todo se consolidó en `develop`.
 
 ---
 
-## 👥 Asignación de Módulos
+## 👥 Roles del Equipo
 
-| Integrante | Rol | Rama Principal | Responsabilidades |
-|---|---|---|---|
-| **Benjamín Paicil** | Scrum Master / Líder | `feature/auth` | Seguridad, ClaveÚnica, autenticación JWT, coordinación general |
-| **Miguel Segovia** | Product Owner | - | Requisitos, priorización, stakeholder management |
-| **Maximiliano López** | Front-End | `feature/frontend` | React 18, Redux, Tailwind, UI/UX, Leaflet, Socket.io-client |
-| **Javier Figueroa** | Back-End | `feature/backend` | NestJS, API REST, MySQL, Gateways, Services |
-| **Ana Araya** | UX/UI & QA | `feature/dashboard` + `feature/marketplace` | Testing, reportes municipales, experiencia de usuario |
+| Integrante | Rol | Áreas de responsabilidad |
+|---|---|---|
+| **Benjamín Paicil** | Scrum Master / Líder | Seguridad, ClaveÚnica, autenticación JWT, coordinación general |
+| **Miguel Segovia** | Product Owner | Requisitos, priorización, stakeholder management |
+| **Maximiliano López** | Front-End | React 18, Redux, Tailwind, UI/UX, Leaflet, Socket.io-client |
+| **Javier Figueroa** | Back-End | NestJS, API REST, MySQL, Gateways, Services |
+| **Ana Araya** | UX/UI & QA | Testing, reportes municipales, experiencia de usuario |
+
+> Los roles indican el área principal de cada quien, pero **todos trabajan sobre `develop`** mediante ramas temporales; ya no hay una rama dedicada por persona.
 
 ---
 
@@ -41,10 +46,11 @@ git clone https://github.com/blindjamin/A.R.C.A.git
 cd "Feria de Software Code"
 ```
 
-### 2. Instalación de ramas
+### 2. Ubicarse en develop
 ```bash
 git fetch origin
-git checkout feature/<tu-modulo>
+git checkout develop
+git pull origin develop
 ```
 
 ### 3. Instalar dependencias
@@ -67,24 +73,37 @@ Crear archivos `.env.local` en cada aplicación (coordinar con el equipo).
 
 ## 📋 Workflow de Colaboración
 
-### Antes de empezar
-1. **Sincronizar con develop:** `git fetch origin && git rebase origin/develop`
-2. **Crear rama local si necesitas:** `git checkout -b feature/<tu-modulo>/<descripción-tarea>`
+Cada tarea = una **rama temporal** creada desde `develop`, que se borra al integrarse.
 
-### Mientras trabajas
-1. **Hacer commits frecuentes** con mensajes claros:
-   ```
-   feat(auth): agregar validación de ClaveÚnica
-   fix(frontend): corregir padding en formulario
-   docs(backend): actualizar schema de usuarios
-   ```
-2. **Pushear cambios regularmente:** `git push origin feature/<tu-modulo>`
+### 1. Antes de empezar — crear rama temporal desde develop
+```bash
+git checkout develop
+git pull origin develop
+git checkout -b <descripción-tarea>   # ej: catalogo-filtros, fix-login
+```
 
-### Antes de hacer PR
-1. **Rebase contra develop:** `git rebase origin/develop`
-2. **Resolver conflictos** si los hay
-3. **Ejecutar tests locales:** `npm test`
-4. **Hacer PR a develop** (no a master)
+### 2. Mientras trabajas
+1. **Commits frecuentes** con mensajes claros (ver convenciones más abajo):
+   ```
+   feat(frontend): agregar filtros al catálogo
+   fix(backend): corregir validación de solicitud
+   ```
+2. (Opcional) Pushear la rama temporal para respaldo: `git push -u origin <rama-temporal>`
+
+### 3. Integrar a develop y borrar la rama temporal
+```bash
+git checkout develop
+git pull origin develop
+git merge <rama-temporal>        # o PR a develop si prefieren revisión
+git push origin develop
+
+# borrar la rama temporal (local y remota si se pusheó)
+git branch -d <rama-temporal>
+git push origin --delete <rama-temporal>   # solo si la pusheaste
+```
+
+### 4. Publicar una versión completa (release)
+Cuando `develop` tiene un hito estable, se sube a `master` (o `main`) **solo en ese momento**, normalmente vía PR `develop → master`. `master` siempre refleja una versión completa.
 
 ---
 
@@ -154,7 +173,10 @@ Closes #<número-issue>
 
 ## ❓ Preguntas Frecuentes
 
-**¿Cómo sincronizo mi rama con los cambios de `develop`?**
+**¿Sobre qué rama trabajo?**
+Siempre creas una **rama temporal desde `develop`** para tu tarea, y la borras al integrarla. No se trabaja directo sobre `develop` ni sobre `master`.
+
+**¿Cómo sincronizo mi rama temporal con los últimos cambios de `develop`?**
 ```bash
 git fetch origin
 git rebase origin/develop
@@ -167,12 +189,15 @@ git add .
 git rebase --continue
 ```
 
-**¿Puedo trabajar en múltiples módulos?**
-Sí, pero crea ramas de feature separadas: `feature/frontend/mi-tarea` vs `feature/auth/mi-tarea`.
+**¿Puedo tener varias tareas a la vez?**
+Sí: una rama temporal por tarea, todas creadas desde `develop`.
+
+**¿Cuándo se toca `master`/`main`?**
+Solo para publicar versiones completas (releases), vía PR `develop → master`.
 
 **¿Dónde reporto bugs?**
 En [GitHub Issues](https://github.com/blindjamin/A.R.C.A/issues) con etiqueta y descripción clara.
 
 ---
 
-**Última actualización:** 2026-06-16 | Equipo COM Tech
+**Última actualización:** 2026-06-23 | Equipo COM Tech

--- a/apps/backend/src/database/migrations/1782163500000-seed-operador-demo.ts
+++ b/apps/backend/src/database/migrations/1782163500000-seed-operador-demo.ts
@@ -1,0 +1,70 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Siembra un usuario demo con DOBLE ROL: la misma persona es ciudadano
+ * (identidad base) Y funcionario municipal (extensión 1:1 sobre usuarios_ciudadanos).
+ *
+ * Modela el caso descrito en el schema: una persona entra con ClaveÚnica y, al
+ * tener extensión de administrador, puede elegir "modo Vecino" o "modo Funcionario"
+ * (el inicio diferido del frontend).
+ *
+ * TEMPORAL — solo para desarrollo/demo. No usar en producción: cuando entre la
+ * auth real (JWT/ClaveÚnica), los funcionarios se darán de alta desde el panel.
+ *
+ * IDs fijos para poder copiarlos en el panel admin:
+ *   - Ciudadano (identidad base): 00000000-0000-4000-8000-000000000002
+ *   - Operador (operador_asignado_id en solicitudes): 00000000-0000-4000-8000-0000000000A2
+ *
+ * El ciudadano dev existente (…0001) se deja intacto, solo como ciudadano.
+ */
+export class SeedOperadorDemo1782163500000 implements MigrationInterface {
+  name = 'SeedOperadorDemo1782163500000';
+
+  private readonly CIUDADANO_ID = '00000000-0000-4000-8000-000000000002';
+  private readonly OPERADOR_ID = '00000000-0000-4000-8000-0000000000A2';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    // 1) Identidad base: la persona como ciudadano (requerida por la FK del admin).
+    await queryRunner.query(`
+      INSERT INTO usuarios_ciudadanos (id, clave_unica_id, fecha_registro, activo)
+      VALUES (
+        '${this.CIUDADANO_ID}',
+        'demo-doble-rol-claveunica',
+        CURRENT_TIMESTAMP,
+        true
+      )
+      ON DUPLICATE KEY UPDATE id = id
+    `);
+
+    // 2) Extensión de administrador: la MISMA persona como operador municipal.
+    await queryRunner.query(`
+      INSERT INTO usuarios_administradores (
+        id, usuario_ciudadano_id, nombre, apellido, email_institucional,
+        telefono_institucional, rol, cargo, fecha_ingreso, activo
+      )
+      VALUES (
+        '${this.OPERADOR_ID}',
+        '${this.CIUDADANO_ID}',
+        'Camila',
+        'Operadora',
+        'camila.operadora@santodomingo.cl',
+        '+56900000002',
+        'operador',
+        'Operadora de retiros municipales',
+        CURRENT_TIMESTAMP,
+        true
+      )
+      ON DUPLICATE KEY UPDATE id = id
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    // Orden inverso: primero la extensión admin, luego la identidad base.
+    await queryRunner.query(
+      `DELETE FROM usuarios_administradores WHERE id = '${this.OPERADOR_ID}'`,
+    );
+    await queryRunner.query(
+      `DELETE FROM usuarios_ciudadanos WHERE id = '${this.CIUDADANO_ID}'`,
+    );
+  }
+}

--- a/apps/backend/src/solicitudes-retiro/dto/cancelar-solicitud-retiro.dto.ts
+++ b/apps/backend/src/solicitudes-retiro/dto/cancelar-solicitud-retiro.dto.ts
@@ -1,0 +1,18 @@
+import {
+  IsNotEmpty,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+} from 'class-validator';
+
+export class CancelarSolicitudRetiroDto {
+  @IsUUID()
+  @IsNotEmpty()
+  usuarioCiudadanoId: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(5000)
+  motivo?: string;
+}

--- a/apps/backend/src/solicitudes-retiro/dto/filter-solicitudes-retiro.dto.ts
+++ b/apps/backend/src/solicitudes-retiro/dto/filter-solicitudes-retiro.dto.ts
@@ -1,0 +1,12 @@
+import { IsEnum, IsOptional, IsUUID } from 'class-validator';
+import { EstadoSolicitudRetiro } from '../entities/estado-solicitud-retiro.enum';
+
+export class FilterSolicitudesRetiroDto {
+  @IsOptional()
+  @IsUUID()
+  usuarioCiudadanoId?: string;
+
+  @IsOptional()
+  @IsEnum(EstadoSolicitudRetiro)
+  estado?: EstadoSolicitudRetiro;
+}

--- a/apps/backend/src/solicitudes-retiro/dto/update-solicitud-retiro.dto.ts
+++ b/apps/backend/src/solicitudes-retiro/dto/update-solicitud-retiro.dto.ts
@@ -1,0 +1,28 @@
+import {
+  IsEnum,
+  IsISO8601,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+} from 'class-validator';
+import { EstadoSolicitudRetiro } from '../entities/estado-solicitud-retiro.enum';
+
+export class UpdateSolicitudRetiroDto {
+  @IsOptional()
+  @IsEnum(EstadoSolicitudRetiro)
+  estado?: EstadoSolicitudRetiro;
+
+  @IsOptional()
+  @IsUUID()
+  operadorAsignadoId?: string;
+
+  @IsOptional()
+  @IsISO8601()
+  fechaProgramada?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(5000)
+  razonRechazo?: string;
+}

--- a/apps/backend/src/solicitudes-retiro/solicitudes-retiro.controller.ts
+++ b/apps/backend/src/solicitudes-retiro/solicitudes-retiro.controller.ts
@@ -1,5 +1,17 @@
-import { Body, Controller, Get, Post, Query } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Get,
+  Param,
+  ParseIntPipe,
+  Patch,
+  Post,
+  Query,
+} from '@nestjs/common';
+import { CancelarSolicitudRetiroDto } from './dto/cancelar-solicitud-retiro.dto';
 import { CreateSolicitudRetiroDto } from './dto/create-solicitud-retiro.dto';
+import { FilterSolicitudesRetiroDto } from './dto/filter-solicitudes-retiro.dto';
+import { UpdateSolicitudRetiroDto } from './dto/update-solicitud-retiro.dto';
 import { SolicitudesRetiroService } from './solicitudes-retiro.service';
 
 @Controller('solicitudes-retiro')
@@ -12,11 +24,28 @@ export class SolicitudesRetiroController {
   }
 
   @Get()
-  findAll(@Query('usuarioCiudadanoId') usuarioCiudadanoId?: string) {
-    if (usuarioCiudadanoId) {
-      return this.solicitudesRetiroService.findByUsuarioCiudadanoId(usuarioCiudadanoId);
-    }
+  findAll(@Query() filtros: FilterSolicitudesRetiroDto) {
+    return this.solicitudesRetiroService.findAll(filtros);
+  }
 
-    return this.solicitudesRetiroService.findAll();
+  @Get(':id')
+  findOne(@Param('id', ParseIntPipe) id: number) {
+    return this.solicitudesRetiroService.findOne(id);
+  }
+
+  @Patch(':id')
+  update(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: UpdateSolicitudRetiroDto,
+  ) {
+    return this.solicitudesRetiroService.update(id, dto);
+  }
+
+  @Patch(':id/cancelar')
+  cancelar(
+    @Param('id', ParseIntPipe) id: number,
+    @Body() dto: CancelarSolicitudRetiroDto,
+  ) {
+    return this.solicitudesRetiroService.cancelarPorCiudadano(id, dto);
   }
 }

--- a/apps/backend/src/solicitudes-retiro/solicitudes-retiro.module.ts
+++ b/apps/backend/src/solicitudes-retiro/solicitudes-retiro.module.ts
@@ -1,6 +1,7 @@
 import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { ResiduosModule } from '../residuos/residuos.module';
+import { UsuarioAdministrador } from '../users/entities/usuario-administrador.entity';
 import { UsuarioCiudadano } from '../users/entities/usuario-ciudadano.entity';
 import { SolicitudRetiro } from './entities/solicitud-retiro.entity';
 import { SolicitudesRetiroController } from './solicitudes-retiro.controller';
@@ -8,7 +9,11 @@ import { SolicitudesRetiroService } from './solicitudes-retiro.service';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([SolicitudRetiro, UsuarioCiudadano]),
+    TypeOrmModule.forFeature([
+      SolicitudRetiro,
+      UsuarioCiudadano,
+      UsuarioAdministrador,
+    ]),
     ResiduosModule,
   ],
   controllers: [SolicitudesRetiroController],

--- a/apps/backend/src/solicitudes-retiro/solicitudes-retiro.service.ts
+++ b/apps/backend/src/solicitudes-retiro/solicitudes-retiro.service.ts
@@ -16,27 +16,6 @@ import { UpdateSolicitudRetiroDto } from './dto/update-solicitud-retiro.dto';
 import { EstadoSolicitudRetiro } from './entities/estado-solicitud-retiro.enum';
 import { SolicitudRetiro } from './entities/solicitud-retiro.entity';
 
-// Transiciones de estado permitidas (desde -> [hacia...])
-const TRANSICIONES_PERMITIDAS: Record<
-  EstadoSolicitudRetiro,
-  EstadoSolicitudRetiro[]
-> = {
-  [EstadoSolicitudRetiro.PENDIENTE]: [
-    EstadoSolicitudRetiro.ASIGNADA,
-    EstadoSolicitudRetiro.CANCELADA,
-  ],
-  [EstadoSolicitudRetiro.ASIGNADA]: [
-    EstadoSolicitudRetiro.EN_PROCESO,
-    EstadoSolicitudRetiro.CANCELADA,
-  ],
-  [EstadoSolicitudRetiro.EN_PROCESO]: [
-    EstadoSolicitudRetiro.COMPLETADA,
-    EstadoSolicitudRetiro.CANCELADA,
-  ],
-  [EstadoSolicitudRetiro.COMPLETADA]: [],
-  [EstadoSolicitudRetiro.CANCELADA]: [],
-};
-
 @Injectable()
 export class SolicitudesRetiroService {
   constructor(
@@ -187,13 +166,8 @@ export class SolicitudesRetiroService {
       return;
     }
 
-    const permitidas = TRANSICIONES_PERMITIDAS[solicitud.estado];
-    if (!permitidas.includes(nuevoEstado)) {
-      throw new BadRequestException(
-        `No se puede cambiar el estado de "${solicitud.estado}" a "${nuevoEstado}"`,
-      );
-    }
-
+    // El panel municipal puede mover el estado en cualquier dirección (incl.
+    // revertir) para operar/probar. Solo se conservan invariantes de datos:
     if (
       nuevoEstado === EstadoSolicitudRetiro.ASIGNADA &&
       !solicitud.operadorAsignadoId
@@ -203,17 +177,11 @@ export class SolicitudesRetiroService {
       );
     }
 
-    if (
-      nuevoEstado === EstadoSolicitudRetiro.CANCELADA &&
-      !solicitud.razonRechazo
-    ) {
-      throw new BadRequestException(
-        'Para cancelar/rechazar la solicitud debe indicar una razón (razonRechazo)',
-      );
-    }
-
     if (nuevoEstado === EstadoSolicitudRetiro.COMPLETADA) {
       solicitud.fechaCompletada = new Date();
+    } else {
+      // Al salir de "completada" la fecha de cierre deja de tener sentido.
+      solicitud.fechaCompletada = null;
     }
 
     solicitud.estado = nuevoEstado;

--- a/apps/backend/src/solicitudes-retiro/solicitudes-retiro.service.ts
+++ b/apps/backend/src/solicitudes-retiro/solicitudes-retiro.service.ts
@@ -1,15 +1,41 @@
 import {
   BadRequestException,
+  ForbiddenException,
   Injectable,
   NotFoundException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { FindOptionsWhere, Repository } from 'typeorm';
 import { ResiduosService } from '../residuos/residuos.service';
+import { UsuarioAdministrador } from '../users/entities/usuario-administrador.entity';
 import { UsuarioCiudadano } from '../users/entities/usuario-ciudadano.entity';
+import { CancelarSolicitudRetiroDto } from './dto/cancelar-solicitud-retiro.dto';
 import { CreateSolicitudRetiroDto } from './dto/create-solicitud-retiro.dto';
+import { FilterSolicitudesRetiroDto } from './dto/filter-solicitudes-retiro.dto';
+import { UpdateSolicitudRetiroDto } from './dto/update-solicitud-retiro.dto';
 import { EstadoSolicitudRetiro } from './entities/estado-solicitud-retiro.enum';
 import { SolicitudRetiro } from './entities/solicitud-retiro.entity';
+
+// Transiciones de estado permitidas (desde -> [hacia...])
+const TRANSICIONES_PERMITIDAS: Record<
+  EstadoSolicitudRetiro,
+  EstadoSolicitudRetiro[]
+> = {
+  [EstadoSolicitudRetiro.PENDIENTE]: [
+    EstadoSolicitudRetiro.ASIGNADA,
+    EstadoSolicitudRetiro.CANCELADA,
+  ],
+  [EstadoSolicitudRetiro.ASIGNADA]: [
+    EstadoSolicitudRetiro.EN_PROCESO,
+    EstadoSolicitudRetiro.CANCELADA,
+  ],
+  [EstadoSolicitudRetiro.EN_PROCESO]: [
+    EstadoSolicitudRetiro.COMPLETADA,
+    EstadoSolicitudRetiro.CANCELADA,
+  ],
+  [EstadoSolicitudRetiro.COMPLETADA]: [],
+  [EstadoSolicitudRetiro.CANCELADA]: [],
+};
 
 @Injectable()
 export class SolicitudesRetiroService {
@@ -18,6 +44,8 @@ export class SolicitudesRetiroService {
     private readonly solicitudRetiroRepository: Repository<SolicitudRetiro>,
     @InjectRepository(UsuarioCiudadano)
     private readonly usuarioCiudadanoRepository: Repository<UsuarioCiudadano>,
+    @InjectRepository(UsuarioAdministrador)
+    private readonly usuarioAdministradorRepository: Repository<UsuarioAdministrador>,
     private readonly residuosService: ResiduosService,
   ) {}
 
@@ -58,18 +86,154 @@ export class SolicitudesRetiroService {
     return this.solicitudRetiroRepository.save(solicitud);
   }
 
-  findAll(): Promise<SolicitudRetiro[]> {
+  findAll(filtros: FilterSolicitudesRetiroDto = {}): Promise<SolicitudRetiro[]> {
+    const where: FindOptionsWhere<SolicitudRetiro> = {};
+
+    if (filtros.usuarioCiudadanoId) {
+      where.usuarioCiudadanoId = filtros.usuarioCiudadanoId;
+    }
+
+    if (filtros.estado) {
+      where.estado = filtros.estado;
+    }
+
     return this.solicitudRetiroRepository.find({
+      where,
       relations: { residuoCatalogo: true },
       order: { fechaSolicitud: 'DESC' },
     });
   }
 
-  findByUsuarioCiudadanoId(usuarioCiudadanoId: string): Promise<SolicitudRetiro[]> {
-    return this.solicitudRetiroRepository.find({
-      where: { usuarioCiudadanoId },
-      relations: { residuoCatalogo: true },
-      order: { fechaSolicitud: 'DESC' },
+  async findOne(id: number): Promise<SolicitudRetiro> {
+    const solicitud = await this.solicitudRetiroRepository.findOne({
+      where: { id },
+      relations: {
+        residuoCatalogo: true,
+        usuarioCiudadano: true,
+        operadorAsignado: true,
+      },
     });
+
+    if (!solicitud) {
+      throw new NotFoundException(`Solicitud de retiro ${id} no encontrada`);
+    }
+
+    return solicitud;
+  }
+
+  async update(
+    id: number,
+    dto: UpdateSolicitudRetiroDto,
+  ): Promise<SolicitudRetiro> {
+    const solicitud = await this.findOne(id);
+
+    if (dto.operadorAsignadoId !== undefined) {
+      await this.validarOperador(dto.operadorAsignadoId);
+      solicitud.operadorAsignadoId = dto.operadorAsignadoId;
+    }
+
+    if (dto.fechaProgramada !== undefined) {
+      solicitud.fechaProgramada = new Date(dto.fechaProgramada);
+    }
+
+    if (dto.razonRechazo !== undefined) {
+      solicitud.razonRechazo = dto.razonRechazo;
+    }
+
+    if (dto.estado !== undefined) {
+      this.aplicarCambioEstado(solicitud, dto);
+    }
+
+    return this.solicitudRetiroRepository.save(solicitud);
+  }
+
+  async cancelarPorCiudadano(
+    id: number,
+    dto: CancelarSolicitudRetiroDto,
+  ): Promise<SolicitudRetiro> {
+    const solicitud = await this.findOne(id);
+
+    if (solicitud.usuarioCiudadanoId !== dto.usuarioCiudadanoId) {
+      throw new ForbiddenException(
+        'No puedes cancelar una solicitud que no es tuya',
+      );
+    }
+
+    const cancelablesPorCiudadano = [
+      EstadoSolicitudRetiro.PENDIENTE,
+      EstadoSolicitudRetiro.ASIGNADA,
+    ];
+
+    if (!cancelablesPorCiudadano.includes(solicitud.estado)) {
+      throw new BadRequestException(
+        `No se puede cancelar una solicitud en estado "${solicitud.estado}"`,
+      );
+    }
+
+    solicitud.estado = EstadoSolicitudRetiro.CANCELADA;
+    solicitud.razonRechazo =
+      dto.motivo ?? 'Cancelada por el ciudadano';
+
+    return this.solicitudRetiroRepository.save(solicitud);
+  }
+
+  private aplicarCambioEstado(
+    solicitud: SolicitudRetiro,
+    dto: UpdateSolicitudRetiroDto,
+  ): void {
+    const nuevoEstado = dto.estado as EstadoSolicitudRetiro;
+
+    if (nuevoEstado === solicitud.estado) {
+      return;
+    }
+
+    const permitidas = TRANSICIONES_PERMITIDAS[solicitud.estado];
+    if (!permitidas.includes(nuevoEstado)) {
+      throw new BadRequestException(
+        `No se puede cambiar el estado de "${solicitud.estado}" a "${nuevoEstado}"`,
+      );
+    }
+
+    if (
+      nuevoEstado === EstadoSolicitudRetiro.ASIGNADA &&
+      !solicitud.operadorAsignadoId
+    ) {
+      throw new BadRequestException(
+        'Para asignar la solicitud debe indicar un operador (operadorAsignadoId)',
+      );
+    }
+
+    if (
+      nuevoEstado === EstadoSolicitudRetiro.CANCELADA &&
+      !solicitud.razonRechazo
+    ) {
+      throw new BadRequestException(
+        'Para cancelar/rechazar la solicitud debe indicar una razón (razonRechazo)',
+      );
+    }
+
+    if (nuevoEstado === EstadoSolicitudRetiro.COMPLETADA) {
+      solicitud.fechaCompletada = new Date();
+    }
+
+    solicitud.estado = nuevoEstado;
+  }
+
+  private async validarOperador(operadorId: string): Promise<void> {
+    const operador = await this.usuarioAdministradorRepository.findOne({
+      where: { id: operadorId },
+    });
+
+    if (!operador) {
+      throw new NotFoundException(`Operador ${operadorId} no encontrado`);
+    }
+
+    if (!operador.activo) {
+      throw new BadRequestException('El operador asignado no está activo');
+    }
+  }
+
+  findByUsuarioCiudadanoId(usuarioCiudadanoId: string): Promise<SolicitudRetiro[]> {
+    return this.findAll({ usuarioCiudadanoId });
   }
 }

--- a/apps/backend/src/users/users.controller.ts
+++ b/apps/backend/src/users/users.controller.ts
@@ -1,0 +1,14 @@
+import { Controller, Get, Param } from '@nestjs/common';
+import { UsersService } from './users.service';
+
+@Controller('usuarios')
+export class UsersController {
+  constructor(private readonly usersService: UsersService) {}
+
+  // Login diferido: tras autenticar, el frontend consulta si esta identidad
+  // tiene extensión de administrador para decidir a qué vista enviarla.
+  @Get(':ciudadanoId/perfil-acceso')
+  getPerfilAcceso(@Param('ciudadanoId') ciudadanoId: string) {
+    return this.usersService.getPerfilAcceso(ciudadanoId);
+  }
+}

--- a/apps/backend/src/users/users.module.ts
+++ b/apps/backend/src/users/users.module.ts
@@ -6,6 +6,7 @@ import {
   UsuarioAdministrador,
   UsuarioCiudadano,
 } from './entities';
+import { UsersController } from './users.controller';
 import { UsersService } from './users.service';
 
 @Module({
@@ -17,6 +18,7 @@ import { UsersService } from './users.service';
       SesionAdministrador,
     ]),
   ],
+  controllers: [UsersController],
   providers: [UsersService],
   exports: [UsersService, TypeOrmModule],
 })

--- a/apps/backend/src/users/users.service.ts
+++ b/apps/backend/src/users/users.service.ts
@@ -1,16 +1,62 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, NotFoundException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { UsuarioCiudadano } from './entities';
+import { UsuarioAdministrador, UsuarioCiudadano } from './entities';
+
+export interface PerfilAcceso {
+  usuarioCiudadanoId: string;
+  esAdministrador: boolean;
+  administrador: {
+    id: string;
+    nombre: string;
+    apellido: string;
+    rol: string;
+  } | null;
+}
 
 @Injectable()
 export class UsersService {
   constructor(
     @InjectRepository(UsuarioCiudadano)
     private readonly usuarioCiudadanoRepository: Repository<UsuarioCiudadano>,
+    @InjectRepository(UsuarioAdministrador)
+    private readonly usuarioAdministradorRepository: Repository<UsuarioAdministrador>,
   ) {}
 
   findCiudadanoByClaveUnicaId(claveUnicaId: string): Promise<UsuarioCiudadano | null> {
     return this.usuarioCiudadanoRepository.findOne({ where: { claveUnicaId } });
+  }
+
+  /**
+   * Resuelve el perfil de acceso de una identidad base: indica si además de
+   * ciudadano tiene extensión de administrador activa (login diferido).
+   */
+  async getPerfilAcceso(ciudadanoId: string): Promise<PerfilAcceso> {
+    const ciudadano = await this.usuarioCiudadanoRepository.findOne({
+      where: { id: ciudadanoId },
+    });
+
+    if (!ciudadano) {
+      throw new NotFoundException(
+        `Usuario ciudadano ${ciudadanoId} no encontrado`,
+      );
+    }
+
+    const admin = await this.usuarioAdministradorRepository.findOne({
+      where: { usuarioCiudadanoId: ciudadanoId, activo: true },
+    });
+
+    return {
+      usuarioCiudadanoId: ciudadano.id,
+      esAdministrador: !!admin,
+      administrador: admin
+        ? {
+            id: admin.id,
+            nombre: admin.nombre,
+            apellido: admin.apellido,
+            rol: admin.rol,
+          }
+        : null,
+    };
   }
 }

--- a/apps/frontend/index.html
+++ b/apps/frontend/index.html
@@ -1,10 +1,17 @@
 <!doctype html>
-<html lang="en">
+<html lang="es">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>frontend</title>
+    <meta name="theme-color" content="#0F6B45" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Bricolage+Grotesque:opsz,wght@12..96,400..800&family=Hanken+Grotesk:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+    <title>A.R.C.A. · Santo Domingo</title>
   </head>
   <body>
     <div id="root"></div>

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -21,9 +21,36 @@ import SugerenciasIA from './pages/SugerenciasIA';
 import SolicitudCreada from './pages/SolicitudCreada';
 import Proximamente from './pages/Proximamente';
 
+function Cargando() {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-canvas text-slate">
+      Cargando…
+    </div>
+  );
+}
+
 function RequireSession({ children }: { children: ReactElement }) {
-  const { usuarioCiudadanoId } = useSession();
+  const { usuarioCiudadanoId, cargando } = useSession();
+  if (cargando) return <Cargando />;
   return usuarioCiudadanoId ? children : <Navigate to="/login" replace />;
+}
+
+function RequireAdmin({ children }: { children: ReactElement }) {
+  const { usuarioCiudadanoId, esAdministrador, cargando } = useSession();
+  if (cargando) return <Cargando />;
+  if (!usuarioCiudadanoId) return <Navigate to="/login" replace />;
+  return esAdministrador ? children : <Navigate to="/inicio" replace />;
+}
+
+// Login diferido: tras autenticar, decide a dónde va la persona.
+//  - sin sesión        → /login
+//  - funcionario       → pantalla de selección de contexto
+//  - solo ciudadano    → directo a la PWA (/inicio)
+function Entrada() {
+  const { usuarioCiudadanoId, esAdministrador, cargando } = useSession();
+  if (cargando) return <Cargando />;
+  if (!usuarioCiudadanoId) return <Navigate to="/login" replace />;
+  return esAdministrador ? <SeleccionInicio /> : <Navigate to="/inicio" replace />;
 }
 
 type Tab = { to: string; label: string; icon: string };
@@ -91,10 +118,13 @@ export default function App() {
       <SolicitudFlowProvider>
         <BrowserRouter>
           <Routes>
-            {/* Inicio diferido: elegir entre app ciudadana y portal admin */}
-            <Route path="/" element={<SeleccionInicio />} />
+            {/* Login diferido: ClaveÚnica primero, luego el gate decide */}
             <Route path="/login" element={<Login />} />
-            <Route path="/admin" element={<AdminSolicitudes />} />
+            <Route path="/" element={<Entrada />} />
+            <Route
+              path="/admin"
+              element={<RequireAdmin><AdminSolicitudes /></RequireAdmin>}
+            />
             <Route path="/inicio" element={<Protected><Inicio /></Protected>} />
 
             {/* Flujo Solicitar retiro: captura → IA → sugerencia → detalle → éxito */}

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -9,6 +9,8 @@ import type { ReactElement } from 'react';
 import { SessionProvider, useSession } from './auth/SessionContext';
 import { SolicitudFlowProvider } from './flow/SolicitudFlow';
 import Login from './pages/Login';
+import SeleccionInicio from './pages/SeleccionInicio';
+import AdminSolicitudes from './pages/AdminSolicitudes';
 import Inicio from './pages/Inicio';
 import Catalogo from './pages/Catalogo';
 import NuevaSolicitud from './pages/NuevaSolicitud';
@@ -89,7 +91,10 @@ export default function App() {
       <SolicitudFlowProvider>
         <BrowserRouter>
           <Routes>
+            {/* Inicio diferido: elegir entre app ciudadana y portal admin */}
+            <Route path="/" element={<SeleccionInicio />} />
             <Route path="/login" element={<Login />} />
+            <Route path="/admin" element={<AdminSolicitudes />} />
             <Route path="/inicio" element={<Protected><Inicio /></Protected>} />
 
             {/* Flujo Solicitar retiro: captura → IA → sugerencia → detalle → éxito */}
@@ -144,7 +149,7 @@ export default function App() {
               }
             />
 
-            <Route path="*" element={<Navigate to="/inicio" replace />} />
+            <Route path="*" element={<Navigate to="/" replace />} />
           </Routes>
         </BrowserRouter>
       </SolicitudFlowProvider>

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,6 +1,5 @@
 import {
   BrowserRouter,
-  Link,
   Navigate,
   NavLink,
   Route,
@@ -8,104 +7,147 @@ import {
 } from 'react-router-dom';
 import type { ReactElement } from 'react';
 import { SessionProvider, useSession } from './auth/SessionContext';
+import { SolicitudFlowProvider } from './flow/SolicitudFlow';
 import Login from './pages/Login';
 import Inicio from './pages/Inicio';
 import Catalogo from './pages/Catalogo';
 import NuevaSolicitud from './pages/NuevaSolicitud';
 import MisSolicitudes from './pages/MisSolicitudes';
+import CapturaResiduo from './pages/CapturaResiduo';
+import AnalizandoIA from './pages/AnalizandoIA';
+import SugerenciasIA from './pages/SugerenciasIA';
+import SolicitudCreada from './pages/SolicitudCreada';
+import Proximamente from './pages/Proximamente';
 
 function RequireSession({ children }: { children: ReactElement }) {
   const { usuarioCiudadanoId } = useSession();
   return usuarioCiudadanoId ? children : <Navigate to="/login" replace />;
 }
 
-function Layout({ children }: { children: ReactElement }) {
-  const { logout } = useSession();
-  const linkClass = ({ isActive }: { isActive: boolean }) =>
-    `px-3 py-1.5 rounded-lg text-sm ${
-      isActive ? 'bg-arca-light text-arca-dark font-medium' : 'text-gray-600'
-    }`;
+type Tab = { to: string; label: string; icon: string };
+const TABS: Tab[] = [
+  { to: '/inicio', label: 'Inicio', icon: '🏠' },
+  { to: '/solicitar', label: 'Solicitar', icon: '📷' },
+  { to: '/mis-solicitudes', label: 'Solicitudes', icon: '📋' },
+];
 
+function TabBar() {
   return (
-    <div className="min-h-screen">
-      <header className="bg-white border-b border-gray-100">
-        <div className="max-w-3xl mx-auto px-4 py-3 flex items-center justify-between">
-          <Link to="/inicio" className="font-bold text-arca-dark">
-            🌿 A.R.C.A.
-          </Link>
-          <nav className="flex items-center gap-1">
-            <NavLink to="/inicio" className={linkClass}>
-              Inicio
-            </NavLink>
-            <NavLink to="/catalogo" className={linkClass}>
-              Catálogo
-            </NavLink>
-            <NavLink to="/mis-solicitudes" className={linkClass}>
-              Mis solicitudes
-            </NavLink>
-            <button
-              onClick={logout}
-              className="ml-2 text-sm text-gray-400 hover:text-gray-600"
+    <nav className="sticky bottom-0 z-10 border-t border-line bg-white/90 backdrop-blur">
+      <ul className="mx-auto flex max-w-md items-stretch justify-around px-2 py-1.5">
+        {TABS.map((tab) => (
+          <li key={tab.to} className="flex-1">
+            <NavLink
+              to={tab.to}
+              className={({ isActive }) =>
+                `flex flex-col items-center gap-0.5 rounded-md py-1.5 text-[11px] font-medium transition-colors ${
+                  isActive ? 'text-green-700' : 'text-slate-2'
+                }`
+              }
             >
-              Salir
-            </button>
-          </nav>
+              <span className="text-xl leading-none">{tab.icon}</span>
+              {tab.label}
+            </NavLink>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}
+
+function Shell({ children }: { children: ReactElement }) {
+  const { logout } = useSession();
+  return (
+    <div className="mx-auto flex min-h-screen max-w-md flex-col bg-canvas shadow-lg">
+      <header className="sticky top-0 z-10 border-b border-line bg-canvas/80 px-5 py-3 backdrop-blur">
+        <div className="flex items-center justify-between">
+          <span className="font-display text-lg font-extrabold tracking-tight text-green-700">
+            A.R.C.A.
+          </span>
+          <button onClick={logout} className="text-xs text-slate-2 hover:text-ink">
+            Salir
+          </button>
         </div>
       </header>
-      <main className="max-w-3xl mx-auto px-4 py-6">{children}</main>
+      <main className="flex-1 px-5 py-5">{children}</main>
+      <TabBar />
     </div>
+  );
+}
+
+function Protected({ children }: { children: ReactElement }) {
+  return (
+    <RequireSession>
+      <Shell>{children}</Shell>
+    </RequireSession>
   );
 }
 
 export default function App() {
   return (
     <SessionProvider>
-      <BrowserRouter>
-        <Routes>
-          <Route path="/login" element={<Login />} />
-          <Route
-            path="/inicio"
-            element={
-              <RequireSession>
-                <Layout>
-                  <Inicio />
-                </Layout>
-              </RequireSession>
-            }
-          />
-          <Route
-            path="/catalogo"
-            element={
-              <RequireSession>
-                <Layout>
-                  <Catalogo />
-                </Layout>
-              </RequireSession>
-            }
-          />
-          <Route
-            path="/nueva-solicitud"
-            element={
-              <RequireSession>
-                <Layout>
-                  <NuevaSolicitud />
-                </Layout>
-              </RequireSession>
-            }
-          />
-          <Route
-            path="/mis-solicitudes"
-            element={
-              <RequireSession>
-                <Layout>
-                  <MisSolicitudes />
-                </Layout>
-              </RequireSession>
-            }
-          />
-          <Route path="*" element={<Navigate to="/inicio" replace />} />
-        </Routes>
-      </BrowserRouter>
+      <SolicitudFlowProvider>
+        <BrowserRouter>
+          <Routes>
+            <Route path="/login" element={<Login />} />
+            <Route path="/inicio" element={<Protected><Inicio /></Protected>} />
+
+            {/* Flujo Solicitar retiro: captura → IA → sugerencia → detalle → éxito */}
+            <Route path="/solicitar" element={<Protected><CapturaResiduo /></Protected>} />
+            <Route
+              path="/solicitar/analizando"
+              element={<Protected><AnalizandoIA /></Protected>}
+            />
+            <Route
+              path="/solicitar/sugerencias"
+              element={<Protected><SugerenciasIA /></Protected>}
+            />
+            <Route path="/catalogo" element={<Protected><Catalogo /></Protected>} />
+            <Route
+              path="/nueva-solicitud"
+              element={<Protected><NuevaSolicitud /></Protected>}
+            />
+            <Route
+              path="/solicitud/creada"
+              element={<Protected><SolicitudCreada /></Protected>}
+            />
+            <Route
+              path="/mis-solicitudes"
+              element={<Protected><MisSolicitudes /></Protected>}
+            />
+
+            {/* Placeholders sin backend todavía */}
+            <Route
+              path="/retiro-municipal"
+              element={
+                <Protected>
+                  <Proximamente
+                    titulo="Retiro municipal"
+                    icono="🚛"
+                    epica="EP-03"
+                    descripcion="Agenda un retiro con la cuadrilla municipal. Estará disponible cuando integremos la gestión de operaciones."
+                  />
+                </Protected>
+              }
+            />
+            <Route
+              path="/marketplace/subir"
+              element={
+                <Protected>
+                  <Proximamente
+                    titulo="Subir al Marketplace"
+                    icono="♻️"
+                    epica="EP-02"
+                    descripcion="Publica tu residuo para que otro vecino lo reutilice. El Marketplace P2P llega en una fase posterior."
+                  />
+                </Protected>
+              }
+            />
+
+            <Route path="*" element={<Navigate to="/inicio" replace />} />
+          </Routes>
+        </BrowserRouter>
+      </SolicitudFlowProvider>
     </SessionProvider>
   );
 }

--- a/apps/frontend/src/api/arca.ts
+++ b/apps/frontend/src/api/arca.ts
@@ -43,6 +43,42 @@ export interface CrearSolicitudInput {
   descripcion?: string;
 }
 
+// --- Overlay visual ---------------------------------------------------------
+// El backend (entidad ResiduoCatalogo) no expone precio ni ícono. Hasta que se
+// agreguen esas columnas, los derivamos en el front por categoría (referencial).
+// Migrar a campos reales cuando el backend los provea.
+
+const PRECIO_POR_CATEGORIA: Record<string, number> = {
+  Muebles: 8000,
+  Electrónica: 12000,
+  'Línea Blanca': 10000,
+  Construcción: 15000,
+  Otros: 5000,
+};
+const PRECIO_DEFAULT = 6000;
+
+const ICONO_POR_CATEGORIA: Record<string, string> = {
+  Muebles: '🛋️',
+  Electrónica: '📺',
+  'Línea Blanca': '🧺',
+  Construcción: '🧱',
+  Otros: '📦',
+};
+const ICONO_DEFAULT = '♻️';
+
+export const precioReferencial = (categoria: string): number =>
+  PRECIO_POR_CATEGORIA[categoria] ?? PRECIO_DEFAULT;
+
+export const iconoPorCategoria = (categoria: string): string =>
+  ICONO_POR_CATEGORIA[categoria] ?? ICONO_DEFAULT;
+
+export const formatearPrecio = (clp: number): string =>
+  clp.toLocaleString('es-CL', {
+    style: 'currency',
+    currency: 'CLP',
+    maximumFractionDigits: 0,
+  });
+
 async function handle<T>(res: Response): Promise<T> {
   if (!res.ok) {
     const body = await res.text();

--- a/apps/frontend/src/api/arca.ts
+++ b/apps/frontend/src/api/arca.ts
@@ -30,11 +30,25 @@ export interface SolicitudRetiro {
   residuoCatalogoId: number;
   estado: EstadoSolicitud;
   descripcion: string | null;
+  direccionAnonimizada?: string | null;
+  latitudCapturada?: string | null;
+  longitudCapturada?: string | null;
   fechaSolicitud: string;
+  fechaProgramada?: string | null;
+  fechaCompletada?: string | null;
+  operadorAsignadoId?: string | null;
+  razonRechazo?: string | null;
   createdAt: string;
   updatedAt: string;
   // El GET incluye la relación anidada; en el POST puede no venir.
   residuoCatalogo?: ResiduoCatalogo;
+}
+
+export interface ActualizarSolicitudInput {
+  estado?: EstadoSolicitud;
+  operadorAsignadoId?: string;
+  fechaProgramada?: string;
+  razonRechazo?: string;
 }
 
 export interface CrearSolicitudInput {
@@ -109,4 +123,31 @@ export function fetchMisSolicitudes(
   const url = new URL(`${API_URL}/solicitudes-retiro`);
   url.searchParams.set('usuarioCiudadanoId', usuarioCiudadanoId);
   return fetch(url).then((r) => handle<SolicitudRetiro[]>(r));
+}
+
+// --- Admin municipal --------------------------------------------------------
+
+export function fetchSolicitudesAdmin(
+  estado?: EstadoSolicitud,
+): Promise<SolicitudRetiro[]> {
+  const url = new URL(`${API_URL}/solicitudes-retiro`);
+  if (estado) url.searchParams.set('estado', estado);
+  return fetch(url).then((r) => handle<SolicitudRetiro[]>(r));
+}
+
+export function fetchSolicitud(id: number): Promise<SolicitudRetiro> {
+  return fetch(`${API_URL}/solicitudes-retiro/${id}`).then((r) =>
+    handle<SolicitudRetiro>(r),
+  );
+}
+
+export function actualizarSolicitud(
+  id: number,
+  data: ActualizarSolicitudInput,
+): Promise<SolicitudRetiro> {
+  return fetch(`${API_URL}/solicitudes-retiro/${id}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  }).then((r) => handle<SolicitudRetiro>(r));
 }

--- a/apps/frontend/src/api/arca.ts
+++ b/apps/frontend/src/api/arca.ts
@@ -125,6 +125,39 @@ export function fetchMisSolicitudes(
   return fetch(url).then((r) => handle<SolicitudRetiro[]>(r));
 }
 
+// --- Identidad / login diferido ---------------------------------------------
+
+export interface PerfilAcceso {
+  usuarioCiudadanoId: string;
+  esAdministrador: boolean;
+  administrador: {
+    id: string;
+    nombre: string;
+    apellido: string;
+    rol: string;
+  } | null;
+}
+
+export function fetchPerfilAcceso(
+  usuarioCiudadanoId: string,
+): Promise<PerfilAcceso> {
+  return fetch(
+    `${API_URL}/usuarios/${usuarioCiudadanoId}/perfil-acceso`,
+  ).then((r) => handle<PerfilAcceso>(r));
+}
+
+export function cancelarSolicitud(
+  id: number,
+  usuarioCiudadanoId: string,
+  motivo?: string,
+): Promise<SolicitudRetiro> {
+  return fetch(`${API_URL}/solicitudes-retiro/${id}/cancelar`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ usuarioCiudadanoId, motivo }),
+  }).then((r) => handle<SolicitudRetiro>(r));
+}
+
 // --- Admin municipal --------------------------------------------------------
 
 export function fetchSolicitudesAdmin(

--- a/apps/frontend/src/auth/SessionContext.tsx
+++ b/apps/frontend/src/auth/SessionContext.tsx
@@ -1,21 +1,30 @@
 import {
   createContext,
+  useCallback,
   useContext,
   useEffect,
   useMemo,
   useState,
   type ReactNode,
 } from 'react';
+import { fetchPerfilAcceso, type PerfilAcceso } from '../api/arca';
 
-// UUID del usuario dev sembrado por migración en el backend.
-// TEMPORAL: cuando Benjamín integre JWT/ClaveÚnica, este id saldrá del token
-// y solo cambiará el interior de `login()` (ver roadmap B.2). Las pantallas no cambian.
-const DEV_USER_ID = '00000000-0000-4000-8000-000000000001';
+// UUIDs sembrados por migración en el backend (auth mock).
+// TEMPORAL: cuando Benjamín integre JWT/ClaveÚnica, la identidad saldrá del token
+// y solo cambiará el interior de `login()`. Las pantallas no cambian.
+export const DEV_USERS = {
+  vecino: '00000000-0000-4000-8000-000000000001', // solo ciudadano
+  funcionario: '00000000-0000-4000-8000-000000000002', // doble rol (ciudadano + operador)
+} as const;
+
 const STORAGE_KEY = 'arca.usuarioCiudadanoId';
 
 interface SessionContextValue {
   usuarioCiudadanoId: string | null;
-  login: () => void;
+  esAdministrador: boolean;
+  perfil: PerfilAcceso | null;
+  cargando: boolean;
+  login: (usuarioCiudadanoId: string) => void;
   logout: () => void;
 }
 
@@ -25,22 +34,60 @@ export function SessionProvider({ children }: { children: ReactNode }) {
   const [usuarioCiudadanoId, setUsuarioCiudadanoId] = useState<string | null>(
     () => localStorage.getItem(STORAGE_KEY),
   );
+  const [perfil, setPerfil] = useState<PerfilAcceso | null>(null);
+  // Arranca cargando si hay sesión persistida (hay que resolver el perfil).
+  const [cargando, setCargando] = useState<boolean>(
+    () => !!localStorage.getItem(STORAGE_KEY),
+  );
 
+  // Resuelve el perfil de acceso (login diferido) cada vez que cambia la identidad.
   useEffect(() => {
-    if (usuarioCiudadanoId) {
-      localStorage.setItem(STORAGE_KEY, usuarioCiudadanoId);
-    } else {
+    if (!usuarioCiudadanoId) {
+      setPerfil(null);
+      setCargando(false);
       localStorage.removeItem(STORAGE_KEY);
+      return;
     }
+
+    localStorage.setItem(STORAGE_KEY, usuarioCiudadanoId);
+    let cancelado = false;
+    setCargando(true);
+
+    fetchPerfilAcceso(usuarioCiudadanoId)
+      .then((p) => {
+        if (!cancelado) setPerfil(p);
+      })
+      .catch(() => {
+        // Si el backend no responde o el id no existe, tratamos como solo-ciudadano.
+        if (!cancelado)
+          setPerfil({
+            usuarioCiudadanoId,
+            esAdministrador: false,
+            administrador: null,
+          });
+      })
+      .finally(() => {
+        if (!cancelado) setCargando(false);
+      });
+
+    return () => {
+      cancelado = true;
+    };
   }, [usuarioCiudadanoId]);
+
+  const login = useCallback((id: string) => setUsuarioCiudadanoId(id), []);
+  const logout = useCallback(() => setUsuarioCiudadanoId(null), []);
 
   const value = useMemo<SessionContextValue>(
     () => ({
       usuarioCiudadanoId,
-      login: () => setUsuarioCiudadanoId(DEV_USER_ID),
-      logout: () => setUsuarioCiudadanoId(null),
+      esAdministrador: perfil?.esAdministrador ?? false,
+      perfil,
+      cargando,
+      login,
+      logout,
     }),
-    [usuarioCiudadanoId],
+    [usuarioCiudadanoId, perfil, cargando, login, logout],
   );
 
   return (

--- a/apps/frontend/src/config/modulos.ts
+++ b/apps/frontend/src/config/modulos.ts
@@ -16,9 +16,9 @@ export const MODULOS: Modulo[] = [
   {
     id: 'solicitar-retiro',
     titulo: 'Solicitar retiro',
-    descripcion: 'Pide el retiro de un residuo voluminoso desde el catálogo.',
-    icono: '🗑️',
-    ruta: '/catalogo',
+    descripcion: 'Toma una foto y la IA identificará el residuo voluminoso.',
+    icono: '📷',
+    ruta: '/solicitar',
     activo: true,
     epica: 'EP-01',
   },

--- a/apps/frontend/src/flow/SolicitudFlow.tsx
+++ b/apps/frontend/src/flow/SolicitudFlow.tsx
@@ -1,0 +1,28 @@
+import { createContext, useContext, useState, type ReactNode } from 'react';
+
+// Estado efímero del flujo "Solicitar retiro" (captura → IA → sugerencia).
+// Vive solo en memoria; al recargar se reinicia y el guard manda a /solicitar.
+interface SolicitudFlowState {
+  fotoPreview: string | null; // dataURL de la foto capturada (solo cosmético)
+  setFotoPreview: (url: string | null) => void;
+  reset: () => void;
+}
+
+const SolicitudFlowContext = createContext<SolicitudFlowState | null>(null);
+
+export function SolicitudFlowProvider({ children }: { children: ReactNode }) {
+  const [fotoPreview, setFotoPreview] = useState<string | null>(null);
+  const reset = () => setFotoPreview(null);
+  return (
+    <SolicitudFlowContext.Provider value={{ fotoPreview, setFotoPreview, reset }}>
+      {children}
+    </SolicitudFlowContext.Provider>
+  );
+}
+
+export function useSolicitudFlow(): SolicitudFlowState {
+  const ctx = useContext(SolicitudFlowContext);
+  if (!ctx)
+    throw new Error('useSolicitudFlow debe usarse dentro de SolicitudFlowProvider');
+  return ctx;
+}

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -8,6 +8,92 @@ body,
   min-height: 100%;
 }
 
-body {
-  @apply bg-gray-50 text-gray-800;
+@layer base {
+  body {
+    @apply bg-canvas text-ink font-body antialiased;
+  }
+  h1,
+  h2,
+  h3 {
+    @apply font-display tracking-tight;
+  }
+}
+
+@layer components {
+  /* Superficies */
+  .card {
+    @apply bg-card rounded-lg border border-line shadow-sm;
+  }
+
+  /* Botones */
+  .btn {
+    @apply inline-flex items-center justify-center gap-2 rounded-pill font-semibold
+      transition-all px-5 py-3 text-sm disabled:opacity-50 disabled:cursor-not-allowed;
+  }
+  .btn-primary {
+    @apply btn text-white shadow-green;
+    background-image: linear-gradient(160deg, #138a57, #0f6b45);
+  }
+  .btn-primary:hover:not(:disabled) {
+    background-image: linear-gradient(160deg, #1bb46f, #0f6b45);
+  }
+  .btn-gold {
+    @apply btn text-ink shadow-gold;
+    background-image: linear-gradient(180deg, #f7b54e, #ef9d24);
+  }
+  .btn-outline {
+    @apply btn bg-white border border-line text-ink-2 hover:border-green-300;
+  }
+  .btn-ghost {
+    @apply btn text-slate hover:text-ink hover:bg-line-2;
+  }
+
+  /* Pills de estado */
+  .pill {
+    @apply inline-flex items-center gap-1 rounded-pill text-xs font-medium px-2.5 py-1;
+  }
+
+  /* Inputs */
+  .field {
+    @apply w-full rounded-md border border-line bg-card-2 px-4 py-3 text-sm
+      outline-none transition-colors focus:border-green-500 focus:bg-white;
+  }
+
+  /* Chips / filtros */
+  .chip {
+    @apply inline-flex items-center rounded-pill border border-line bg-white px-3.5 py-1.5
+      text-sm text-slate transition-colors cursor-pointer hover:border-green-300;
+  }
+  .chip-active {
+    @apply border-transparent bg-green-700 text-white;
+  }
+}
+
+@layer utilities {
+  /* Línea de escaneo del análisis IA */
+  .scanline {
+    position: absolute;
+    left: 0;
+    right: 0;
+    height: 3px;
+    background: linear-gradient(90deg, transparent, #1bb46f, transparent);
+    box-shadow: 0 0 14px 2px rgba(27, 180, 111, 0.6);
+    animation: scan 1.8s ease-in-out infinite;
+  }
+  @keyframes scan {
+    0% { top: 8%; }
+    50% { top: 88%; }
+    100% { top: 8%; }
+  }
+
+  /* Pulso del SuccessRing */
+  .success-ring {
+    box-shadow: 0 0 0 0 rgba(239, 157, 36, 0.5);
+    animation: success-pulse 1.6s ease-out infinite;
+  }
+  @keyframes success-pulse {
+    0% { box-shadow: 0 0 0 0 rgba(239, 157, 36, 0.45); }
+    70% { box-shadow: 0 0 0 18px rgba(239, 157, 36, 0); }
+    100% { box-shadow: 0 0 0 0 rgba(239, 157, 36, 0); }
+  }
 }

--- a/apps/frontend/src/pages/AdminSolicitudes.tsx
+++ b/apps/frontend/src/pages/AdminSolicitudes.tsx
@@ -15,6 +15,14 @@ const ESTADO_META: Record<EstadoSolicitud, { label: string; cls: string }> = {
   cancelada: { label: 'Cancelada', cls: 'bg-line-2 text-slate' },
 };
 
+const ESTADOS: EstadoSolicitud[] = [
+  'pendiente',
+  'asignada',
+  'en_proceso',
+  'completada',
+  'cancelada',
+];
+
 const FILTROS: { value: EstadoSolicitud | 'todas'; label: string }[] = [
   { value: 'todas', label: 'Todas' },
   { value: 'pendiente', label: 'Pendientes' },
@@ -193,28 +201,32 @@ function DetalleSolicitud({
     }
   };
 
-  const asignar = () => {
-    if (!operadorId.trim()) {
-      setError('Indica el ID del operador para asignar.');
-      return;
-    }
-    aplicar({
-      estado: 'asignada',
-      operadorAsignadoId: operadorId.trim(),
-      ...(fechaProgramada
-        ? { fechaProgramada: new Date(fechaProgramada).toISOString() }
-        : {}),
-    });
-  };
+  const cambiarEstado = (nuevo: EstadoSolicitud) => {
+    if (nuevo === solicitud.estado || guardando) return;
 
-  const cancelar = () => {
-    const razon = window.prompt('Motivo de la cancelación / rechazo:');
-    if (razon === null) return;
-    if (!razon.trim()) {
-      setError('Debes indicar una razón para cancelar.');
+    if (nuevo === 'asignada') {
+      const op = operadorId.trim() || solicitud.operadorAsignadoId || '';
+      if (!op) {
+        setError('Indica el ID del operador para asignar.');
+        return;
+      }
+      aplicar({
+        estado: 'asignada',
+        operadorAsignadoId: op,
+        ...(fechaProgramada
+          ? { fechaProgramada: new Date(fechaProgramada).toISOString() }
+          : {}),
+      });
       return;
     }
-    aplicar({ estado: 'cancelada', razonRechazo: razon.trim() });
+
+    if (nuevo === 'cancelada') {
+      const razon = window.prompt('Motivo de la cancelación / rechazo (opcional):') ?? '';
+      aplicar({ estado: 'cancelada', ...(razon.trim() ? { razonRechazo: razon.trim() } : {}) });
+      return;
+    }
+
+    aplicar({ estado: nuevo });
   };
 
   return (
@@ -261,73 +273,48 @@ function DetalleSolicitud({
 
       {error && <p className="text-sm text-rose-600">{error}</p>}
 
-      {/* Acciones según estado actual (la validación final la hace el backend) */}
+      {/* Cambio de estado libre (incl. revertir), para operar/probar el flujo. */}
       <div className="card space-y-3 p-5">
-        <h2 className="font-bold">Acciones</h2>
+        <h2 className="font-bold">Cambiar estado</h2>
 
-        {solicitud.estado === 'pendiente' && (
-          <div className="space-y-2">
-            <input
-              value={operadorId}
-              onChange={(e) => setOperadorId(e.target.value)}
-              placeholder="ID del operador (UUID)"
-              className="w-full rounded-md border border-line px-3 py-2 text-sm"
-            />
-            <input
-              type="datetime-local"
-              value={fechaProgramada}
-              onChange={(e) => setFechaProgramada(e.target.value)}
-              className="w-full rounded-md border border-line px-3 py-2 text-sm"
-            />
-            <button
-              onClick={asignar}
-              disabled={guardando}
-              className="btn-primary w-full"
-            >
-              Asignar operador
-            </button>
-          </div>
-        )}
+        <div className="space-y-2">
+          <input
+            value={operadorId}
+            onChange={(e) => setOperadorId(e.target.value)}
+            placeholder="ID del operador (UUID) — requerido para asignar"
+            className="w-full rounded-md border border-line px-3 py-2 text-sm"
+          />
+          <input
+            type="datetime-local"
+            value={fechaProgramada}
+            onChange={(e) => setFechaProgramada(e.target.value)}
+            className="w-full rounded-md border border-line px-3 py-2 text-sm"
+          />
+        </div>
 
-        {solicitud.estado === 'asignada' && (
-          <button
-            onClick={() => aplicar({ estado: 'en_proceso' })}
-            disabled={guardando}
-            className="btn-primary w-full"
-          >
-            Iniciar retiro (en ruta)
-          </button>
-        )}
-
-        {solicitud.estado === 'en_proceso' && (
-          <button
-            onClick={() => aplicar({ estado: 'completada' })}
-            disabled={guardando}
-            className="btn-primary w-full"
-          >
-            Marcar como completada
-          </button>
-        )}
-
-        {(solicitud.estado === 'pendiente' ||
-          solicitud.estado === 'asignada' ||
-          solicitud.estado === 'en_proceso') && (
-          <button
-            onClick={cancelar}
-            disabled={guardando}
-            className="w-full rounded-pill border border-rose-300 py-2.5 text-sm font-medium text-rose-600 transition-colors hover:bg-rose-50"
-          >
-            Cancelar / rechazar
-          </button>
-        )}
-
-        {(solicitud.estado === 'completada' ||
-          solicitud.estado === 'cancelada') && (
-          <p className="text-sm text-slate">
-            Esta solicitud ya está {meta.label.toLowerCase()}. No admite más
-            cambios.
-          </p>
-        )}
+        <div className="grid grid-cols-2 gap-2">
+          {ESTADOS.map((est) => {
+            const m = ESTADO_META[est];
+            const actual = est === solicitud.estado;
+            return (
+              <button
+                key={est}
+                onClick={() => cambiarEstado(est)}
+                disabled={guardando || actual}
+                className={`pill justify-center py-2 text-sm ${
+                  actual
+                    ? `${m.cls} ring-2 ring-offset-1 ring-green-600`
+                    : 'border border-line text-ink hover:bg-canvas'
+                } disabled:cursor-default`}
+              >
+                {actual ? `● ${m.label}` : m.label}
+              </button>
+            );
+          })}
+        </div>
+        <p className="text-xs text-slate-2">
+          Estado actual marcado con ●. Puedes avanzar o revertir libremente.
+        </p>
       </div>
     </div>
   );

--- a/apps/frontend/src/pages/AdminSolicitudes.tsx
+++ b/apps/frontend/src/pages/AdminSolicitudes.tsx
@@ -1,0 +1,351 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  actualizarSolicitud,
+  fetchSolicitudesAdmin,
+  type EstadoSolicitud,
+  type SolicitudRetiro,
+} from '../api/arca';
+
+const ESTADO_META: Record<EstadoSolicitud, { label: string; cls: string }> = {
+  pendiente: { label: 'Pendiente', cls: 'bg-gold-100 text-gold-600' },
+  asignada: { label: 'Asignada', cls: 'bg-sky-100 text-sky-600' },
+  en_proceso: { label: 'En ruta', cls: 'bg-green-100 text-green-700' },
+  completada: { label: 'Completada', cls: 'bg-green-600 text-white' },
+  cancelada: { label: 'Cancelada', cls: 'bg-line-2 text-slate' },
+};
+
+const FILTROS: { value: EstadoSolicitud | 'todas'; label: string }[] = [
+  { value: 'todas', label: 'Todas' },
+  { value: 'pendiente', label: 'Pendientes' },
+  { value: 'asignada', label: 'Asignadas' },
+  { value: 'en_proceso', label: 'En ruta' },
+  { value: 'completada', label: 'Completadas' },
+  { value: 'cancelada', label: 'Canceladas' },
+];
+
+const formatoFecha = (iso?: string | null): string =>
+  iso
+    ? new Date(iso).toLocaleString('es-CL', {
+        day: '2-digit',
+        month: 'short',
+        hour: '2-digit',
+        minute: '2-digit',
+      })
+    : '—';
+
+export default function AdminSolicitudes() {
+  const navigate = useNavigate();
+  const [filtro, setFiltro] = useState<EstadoSolicitud | 'todas'>('todas');
+  const [items, setItems] = useState<SolicitudRetiro[]>([]);
+  const [seleccion, setSeleccion] = useState<SolicitudRetiro | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const cargar = () => {
+    setLoading(true);
+    fetchSolicitudesAdmin(filtro === 'todas' ? undefined : filtro)
+      .then(setItems)
+      .catch((e: Error) => setError(e.message))
+      .finally(() => setLoading(false));
+  };
+
+  useEffect(() => {
+    cargar();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [filtro]);
+
+  const onActualizada = () => {
+    setSeleccion(null);
+    cargar();
+  };
+
+  return (
+    <div className="mx-auto flex min-h-screen max-w-2xl flex-col bg-canvas shadow-lg">
+      <header className="sticky top-0 z-10 border-b border-line bg-canvas/80 px-5 py-3 backdrop-blur">
+        <div className="flex items-center justify-between">
+          <span className="font-display text-lg font-extrabold tracking-tight text-green-700">
+            A.R.C.A. · Admin
+          </span>
+          <button
+            onClick={() => navigate('/')}
+            className="text-xs text-slate-2 hover:text-ink"
+          >
+            Salir
+          </button>
+        </div>
+      </header>
+
+      <main className="flex-1 px-5 py-5">
+        {seleccion ? (
+          <DetalleSolicitud
+            solicitud={seleccion}
+            onVolver={() => setSeleccion(null)}
+            onActualizada={onActualizada}
+          />
+        ) : (
+          <div className="space-y-4">
+            <header>
+              <h1 className="text-2xl font-extrabold">Solicitudes de retiro</h1>
+              <p className="text-sm text-slate">
+                Revisa, asigna y gestiona los retiros municipales.
+              </p>
+            </header>
+
+            <div className="-mx-1 flex gap-2 overflow-x-auto px-1 pb-1">
+              {FILTROS.map((f) => (
+                <button
+                  key={f.value}
+                  onClick={() => setFiltro(f.value)}
+                  className={`pill shrink-0 ${
+                    filtro === f.value
+                      ? 'bg-green-700 text-white'
+                      : 'bg-line-2 text-slate'
+                  }`}
+                >
+                  {f.label}
+                </button>
+              ))}
+            </div>
+
+            {loading ? (
+              <p className="text-slate">Cargando solicitudes…</p>
+            ) : error ? (
+              <p className="text-rose-600">{error}</p>
+            ) : items.length === 0 ? (
+              <div className="card p-8 text-center">
+                <p className="text-sm text-slate">
+                  No hay solicitudes en este estado.
+                </p>
+              </div>
+            ) : (
+              <ul className="space-y-3">
+                {items.map((s) => {
+                  const meta = ESTADO_META[s.estado];
+                  return (
+                    <li key={s.id}>
+                      <button
+                        onClick={() => setSeleccion(s)}
+                        className="card flex w-full items-center gap-3 p-4 text-left transition-colors hover:bg-green-50/40"
+                      >
+                        <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-md bg-green-50 text-xl">
+                          ♻️
+                        </div>
+                        <div className="min-w-0 flex-1">
+                          <div className="flex items-center justify-between gap-2">
+                            <p className="truncate font-bold">
+                              #{s.id} ·{' '}
+                              {s.residuoCatalogo?.nombre ??
+                                `Residuo ${s.residuoCatalogoId}`}
+                            </p>
+                            <span className={`pill ${meta.cls}`}>
+                              {meta.label}
+                            </span>
+                          </div>
+                          <p className="truncate text-sm text-slate">
+                            {s.descripcion ?? 'Sin descripción'}
+                          </p>
+                          <p className="text-xs text-slate-2">
+                            {formatoFecha(s.fechaSolicitud)}
+                          </p>
+                        </div>
+                      </button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}
+
+// --- Detalle + acciones -----------------------------------------------------
+
+function DetalleSolicitud({
+  solicitud,
+  onVolver,
+  onActualizada,
+}: {
+  solicitud: SolicitudRetiro;
+  onVolver: () => void;
+  onActualizada: () => void;
+}) {
+  const [operadorId, setOperadorId] = useState('');
+  const [fechaProgramada, setFechaProgramada] = useState('');
+  const [guardando, setGuardando] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const meta = ESTADO_META[solicitud.estado];
+
+  const aplicar = async (cambios: Parameters<typeof actualizarSolicitud>[1]) => {
+    setGuardando(true);
+    setError(null);
+    try {
+      await actualizarSolicitud(solicitud.id, cambios);
+      onActualizada();
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setGuardando(false);
+    }
+  };
+
+  const asignar = () => {
+    if (!operadorId.trim()) {
+      setError('Indica el ID del operador para asignar.');
+      return;
+    }
+    aplicar({
+      estado: 'asignada',
+      operadorAsignadoId: operadorId.trim(),
+      ...(fechaProgramada
+        ? { fechaProgramada: new Date(fechaProgramada).toISOString() }
+        : {}),
+    });
+  };
+
+  const cancelar = () => {
+    const razon = window.prompt('Motivo de la cancelación / rechazo:');
+    if (razon === null) return;
+    if (!razon.trim()) {
+      setError('Debes indicar una razón para cancelar.');
+      return;
+    }
+    aplicar({ estado: 'cancelada', razonRechazo: razon.trim() });
+  };
+
+  return (
+    <div className="space-y-4">
+      <button
+        onClick={onVolver}
+        className="text-sm text-slate-2 hover:text-ink"
+      >
+        ← Volver al listado
+      </button>
+
+      <div className="card space-y-3 p-5">
+        <div className="flex items-start justify-between gap-2">
+          <div>
+            <h1 className="text-xl font-extrabold">
+              Solicitud #{solicitud.id}
+            </h1>
+            <p className="text-sm text-slate">
+              {solicitud.residuoCatalogo?.nombre ??
+                `Residuo ${solicitud.residuoCatalogoId}`}
+            </p>
+          </div>
+          <span className={`pill ${meta.cls}`}>{meta.label}</span>
+        </div>
+
+        <dl className="grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+          <Dato label="Categoría" valor={solicitud.residuoCatalogo?.categoria} />
+          <Dato label="Ciudadano" valor={solicitud.usuarioCiudadanoId} />
+          <Dato label="Solicitada" valor={formatoFecha(solicitud.fechaSolicitud)} />
+          <Dato label="Programada" valor={formatoFecha(solicitud.fechaProgramada)} />
+          <Dato label="Completada" valor={formatoFecha(solicitud.fechaCompletada)} />
+          <Dato label="Operador" valor={solicitud.operadorAsignadoId} />
+          <Dato
+            label="Dirección"
+            valor={solicitud.direccionAnonimizada}
+            full
+          />
+          <Dato label="Descripción" valor={solicitud.descripcion} full />
+          {solicitud.razonRechazo && (
+            <Dato label="Razón rechazo" valor={solicitud.razonRechazo} full />
+          )}
+        </dl>
+      </div>
+
+      {error && <p className="text-sm text-rose-600">{error}</p>}
+
+      {/* Acciones según estado actual (la validación final la hace el backend) */}
+      <div className="card space-y-3 p-5">
+        <h2 className="font-bold">Acciones</h2>
+
+        {solicitud.estado === 'pendiente' && (
+          <div className="space-y-2">
+            <input
+              value={operadorId}
+              onChange={(e) => setOperadorId(e.target.value)}
+              placeholder="ID del operador (UUID)"
+              className="w-full rounded-md border border-line px-3 py-2 text-sm"
+            />
+            <input
+              type="datetime-local"
+              value={fechaProgramada}
+              onChange={(e) => setFechaProgramada(e.target.value)}
+              className="w-full rounded-md border border-line px-3 py-2 text-sm"
+            />
+            <button
+              onClick={asignar}
+              disabled={guardando}
+              className="btn-primary w-full"
+            >
+              Asignar operador
+            </button>
+          </div>
+        )}
+
+        {solicitud.estado === 'asignada' && (
+          <button
+            onClick={() => aplicar({ estado: 'en_proceso' })}
+            disabled={guardando}
+            className="btn-primary w-full"
+          >
+            Iniciar retiro (en ruta)
+          </button>
+        )}
+
+        {solicitud.estado === 'en_proceso' && (
+          <button
+            onClick={() => aplicar({ estado: 'completada' })}
+            disabled={guardando}
+            className="btn-primary w-full"
+          >
+            Marcar como completada
+          </button>
+        )}
+
+        {(solicitud.estado === 'pendiente' ||
+          solicitud.estado === 'asignada' ||
+          solicitud.estado === 'en_proceso') && (
+          <button
+            onClick={cancelar}
+            disabled={guardando}
+            className="w-full rounded-pill border border-rose-300 py-2.5 text-sm font-medium text-rose-600 transition-colors hover:bg-rose-50"
+          >
+            Cancelar / rechazar
+          </button>
+        )}
+
+        {(solicitud.estado === 'completada' ||
+          solicitud.estado === 'cancelada') && (
+          <p className="text-sm text-slate">
+            Esta solicitud ya está {meta.label.toLowerCase()}. No admite más
+            cambios.
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Dato({
+  label,
+  valor,
+  full,
+}: {
+  label: string;
+  valor?: string | null;
+  full?: boolean;
+}) {
+  return (
+    <div className={full ? 'col-span-2' : ''}>
+      <dt className="text-xs uppercase tracking-wide text-slate-2">{label}</dt>
+      <dd className="break-words text-ink">{valor || '—'}</dd>
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/AnalizandoIA.tsx
+++ b/apps/frontend/src/pages/AnalizandoIA.tsx
@@ -1,0 +1,41 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useSolicitudFlow } from '../flow/SolicitudFlow';
+
+export default function AnalizandoIA() {
+  const navigate = useNavigate();
+  const { fotoPreview } = useSolicitudFlow();
+
+  // Reconocimiento IA simulado: avanza solo tras la "verificación".
+  useEffect(() => {
+    const t = setTimeout(() => navigate('/solicitar/sugerencias'), 2200);
+    return () => clearTimeout(t);
+  }, [navigate]);
+
+  return (
+    <div className="flex flex-col items-center gap-6 py-6 text-center">
+      <header>
+        <h1 className="text-2xl font-extrabold">Analizando…</h1>
+        <p className="text-sm text-slate">Identificando el objeto con IA local.</p>
+      </header>
+
+      <div className="relative aspect-[4/5] w-full overflow-hidden rounded-lg border border-line bg-ink">
+        {fotoPreview && (
+          <img
+            src={fotoPreview}
+            alt="Analizando residuo"
+            className="h-full w-full object-cover opacity-80"
+          />
+        )}
+        {/* Línea de escaneo */}
+        <div className="scanline" />
+        <div className="absolute inset-6 rounded-md border-2 border-green-500/70" />
+      </div>
+
+      <div className="flex items-center gap-2 text-sm font-medium text-green-700">
+        <span className="h-2 w-2 animate-ping rounded-full bg-green-500" />
+        Verificando características…
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/CapturaResiduo.tsx
+++ b/apps/frontend/src/pages/CapturaResiduo.tsx
@@ -1,0 +1,88 @@
+import { useRef, type ChangeEvent } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useSolicitudFlow } from '../flow/SolicitudFlow';
+
+export default function CapturaResiduo() {
+  const navigate = useNavigate();
+  const { fotoPreview, setFotoPreview } = useSolicitudFlow();
+  const camaraRef = useRef<HTMLInputElement>(null);
+  const galeriaRef = useRef<HTMLInputElement>(null);
+
+  // La captura es solo visual: si el usuario elige una foto la mostramos,
+  // pero no es obligatoria para continuar.
+  const handleFile = (e: ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => setFotoPreview(reader.result as string);
+    reader.readAsDataURL(file);
+  };
+
+  return (
+    <div className="space-y-5">
+      <header>
+        <h1 className="text-2xl font-extrabold">Captura el residuo</h1>
+        <p className="text-sm text-slate">
+          Toma una foto y la IA identificará el objeto.
+        </p>
+      </header>
+
+      {/* Visor / preview */}
+      <div className="relative aspect-[4/5] overflow-hidden rounded-lg border border-line bg-ink">
+        {fotoPreview ? (
+          <img
+            src={fotoPreview}
+            alt="Residuo capturado"
+            className="h-full w-full object-cover"
+          />
+        ) : (
+          <div className="flex h-full flex-col items-center justify-center gap-3 text-white/70">
+            <span className="text-5xl">📷</span>
+            <p className="text-sm">Encuadra el objeto completo</p>
+            <div className="pointer-events-none absolute inset-6 rounded-md border-2 border-dashed border-white/30" />
+          </div>
+        )}
+      </div>
+
+      {/* Inputs opcionales: cámara y galería */}
+      <input
+        ref={camaraRef}
+        type="file"
+        accept="image/*"
+        capture="environment"
+        className="hidden"
+        onChange={handleFile}
+      />
+      <input
+        ref={galeriaRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={handleFile}
+      />
+
+      <div className="space-y-3">
+        <button
+          onClick={() => navigate('/solicitar/analizando')}
+          className="btn-primary w-full py-3.5"
+        >
+          Analizar con IA
+        </button>
+        <div className="flex gap-3">
+          <button
+            onClick={() => camaraRef.current?.click()}
+            className="btn-outline flex-1"
+          >
+            📷 Cámara
+          </button>
+          <button
+            onClick={() => galeriaRef.current?.click()}
+            className="btn-outline flex-1"
+          >
+            🖼️ Galería
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/Catalogo.tsx
+++ b/apps/frontend/src/pages/Catalogo.tsx
@@ -1,11 +1,19 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { fetchCatalogo, type ResiduoCatalogo } from '../api/arca';
+import {
+  fetchCatalogo,
+  formatearPrecio,
+  iconoPorCategoria,
+  precioReferencial,
+  type ResiduoCatalogo,
+} from '../api/arca';
 
 export default function Catalogo() {
   const [items, setItems] = useState<ResiduoCatalogo[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState('');
+  const [categoria, setCategoria] = useState<string>('Todos');
   const navigate = useNavigate();
 
   useEffect(() => {
@@ -15,41 +23,80 @@ export default function Catalogo() {
       .finally(() => setLoading(false));
   }, []);
 
-  if (loading) return <p className="text-gray-500">Cargando catálogo…</p>;
-  if (error) return <p className="text-red-600">{error}</p>;
+  const categorias = useMemo(
+    () => ['Todos', ...new Set(items.map((i) => i.categoria))],
+    [items],
+  );
+
+  const filtrados = items.filter((i) => {
+    const matchCat = categoria === 'Todos' || i.categoria === categoria;
+    const matchText = i.nombre.toLowerCase().includes(query.toLowerCase());
+    return matchCat && matchText;
+  });
+
+  if (loading) return <p className="text-slate">Cargando catálogo…</p>;
+  if (error) return <p className="text-rose-600">{error}</p>;
 
   return (
-    <div>
-      <h2 className="text-xl font-bold text-arca-dark mb-4">
-        Catálogo de residuos
-      </h2>
+    <div className="space-y-4">
+      <header>
+        <h1 className="text-2xl font-extrabold">Catálogo</h1>
+        <p className="text-sm text-slate">Residuos voluminosos y su valor de retiro.</p>
+      </header>
 
-      <div className="grid gap-3 sm:grid-cols-2">
-        {items.map((item) => (
-          <div
-            key={item.id}
-            className="bg-white rounded-xl shadow-sm border border-gray-100 p-4 flex flex-col"
+      <input
+        type="search"
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        placeholder="Buscar sofá, refrigerador…"
+        className="field"
+      />
+
+      <div className="-mx-5 flex gap-2 overflow-x-auto px-5 pb-1">
+        {categorias.map((cat) => (
+          <button
+            key={cat}
+            onClick={() => setCategoria(cat)}
+            className={`chip whitespace-nowrap ${
+              categoria === cat ? 'chip-active' : ''
+            }`}
           >
-            <div className="flex items-center justify-between">
-              <h3 className="font-semibold">{item.nombre}</h3>
-              {item.puedeReutilizarse && (
-                <span className="text-xs bg-arca-light text-arca-dark px-2 py-0.5 rounded-full">
-                  Reutilizable
-                </span>
-              )}
+            {cat}
+          </button>
+        ))}
+      </div>
+
+      <div className="grid gap-3">
+        {filtrados.map((item) => (
+          <div key={item.id} className="card flex items-center gap-3 p-3">
+            <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-md bg-green-50 text-2xl">
+              {iconoPorCategoria(item.categoria)}
             </div>
-            <p className="text-sm text-gray-500">{item.categoria}</p>
-            {item.descripcion && (
-              <p className="text-sm text-gray-600 mt-1">{item.descripcion}</p>
-            )}
+            <div className="min-w-0 flex-1">
+              <div className="flex items-center gap-2">
+                <h3 className="truncate font-bold">{item.nombre}</h3>
+                {item.puedeReutilizarse && (
+                  <span className="pill bg-gold-100 text-gold-600">Reutilizable</span>
+                )}
+              </div>
+              <p className="text-xs text-slate">{item.categoria}</p>
+              <p className="mt-0.5 font-display text-sm font-extrabold text-green-700">
+                {formatearPrecio(precioReferencial(item.categoria))}
+              </p>
+            </div>
             <button
               onClick={() => navigate(`/nueva-solicitud?residuo=${item.id}`)}
-              className="mt-3 self-start text-sm bg-arca-green hover:bg-arca-dark text-white px-3 py-1.5 rounded-lg transition-colors"
+              className="btn-primary shrink-0 px-4 py-2 text-xs"
             >
-              Solicitar retiro
+              Solicitar
             </button>
           </div>
         ))}
+        {filtrados.length === 0 && (
+          <p className="py-8 text-center text-sm text-slate">
+            Sin resultados para tu búsqueda.
+          </p>
+        )}
       </div>
     </div>
   );

--- a/apps/frontend/src/pages/Inicio.tsx
+++ b/apps/frontend/src/pages/Inicio.tsx
@@ -10,25 +10,22 @@ function ModuloCard({ modulo }: { modulo: Modulo }) {
       type="button"
       disabled={!clickable}
       onClick={() => clickable && navigate(modulo.ruta!)}
-      className={`text-left bg-white rounded-2xl border border-gray-100 p-5 transition-all ${
+      className={`card flex flex-col items-start p-4 text-left transition-all ${
         clickable
-          ? 'shadow-sm hover:shadow-md hover:border-arca-green cursor-pointer'
-          : 'opacity-60 cursor-not-allowed'
+          ? 'hover:-translate-y-0.5 hover:shadow-md hover:border-green-300'
+          : 'opacity-60'
       }`}
     >
-      <div className="flex items-start justify-between">
-        <span className="text-3xl">{modulo.icono}</span>
+      <div className="flex w-full items-start justify-between">
+        <span className="flex h-11 w-11 items-center justify-center rounded-md bg-green-50 text-2xl">
+          {modulo.icono}
+        </span>
         {!modulo.activo && (
-          <span className="text-xs bg-gray-100 text-gray-500 px-2 py-0.5 rounded-full">
-            Próximamente
-          </span>
+          <span className="pill bg-line-2 text-slate">Pronto</span>
         )}
       </div>
-      <h3 className="font-semibold mt-3">{modulo.titulo}</h3>
-      <p className="text-sm text-gray-500 mt-1">{modulo.descripcion}</p>
-      <span className="inline-block text-[10px] text-gray-400 mt-3">
-        {modulo.epica}
-      </span>
+      <h3 className="mt-3 text-base font-bold">{modulo.titulo}</h3>
+      <p className="mt-1 text-sm leading-snug text-slate">{modulo.descripcion}</p>
     </button>
   );
 }
@@ -40,17 +37,43 @@ export default function Inicio() {
   );
 
   return (
-    <div>
-      <header className="mb-6">
-        <h1 className="text-2xl font-bold text-arca-dark">Hola, vecino 🌿</h1>
-        <p className="text-gray-500">¿Qué quieres hacer hoy?</p>
+    <div className="space-y-6">
+      <header>
+        <p className="text-sm text-slate">Hola de nuevo,</p>
+        <h1 className="text-2xl font-extrabold">Camila 👋</h1>
       </header>
 
-      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {modulos.map((modulo) => (
-          <ModuloCard key={modulo.id} modulo={modulo} />
-        ))}
-      </div>
+      {/* Tarjeta de impacto / Circular Credits (datos demo) */}
+      <section
+        className="rounded-lg p-5 text-white shadow-green"
+        style={{ backgroundImage: 'linear-gradient(140deg,#156f4a,#0f6b45,#0a4f37)' }}
+      >
+        <p className="text-xs font-medium uppercase tracking-widest text-green-100">
+          Circular Credits
+        </p>
+        <p className="mt-1 font-display text-4xl font-extrabold">120</p>
+        <div className="mt-4 flex gap-6 text-sm">
+          <div>
+            <p className="font-bold">312 kg</p>
+            <p className="text-green-100/80">CO₂ evitado</p>
+          </div>
+          <div>
+            <p className="font-bold">8</p>
+            <p className="text-green-100/80">Reutilizados</p>
+          </div>
+        </div>
+      </section>
+
+      <section>
+        <h2 className="mb-3 text-sm font-semibold uppercase tracking-wide text-slate">
+          ¿Qué quieres hacer hoy?
+        </h2>
+        <div className="grid grid-cols-2 gap-3">
+          {modulos.map((modulo) => (
+            <ModuloCard key={modulo.id} modulo={modulo} />
+          ))}
+        </div>
+      </section>
     </div>
   );
 }

--- a/apps/frontend/src/pages/Login.tsx
+++ b/apps/frontend/src/pages/Login.tsx
@@ -1,13 +1,14 @@
 import { useNavigate } from 'react-router-dom';
-import { useSession } from '../auth/SessionContext';
+import { DEV_USERS, useSession } from '../auth/SessionContext';
 
 export default function Login() {
   const { login } = useSession();
   const navigate = useNavigate();
 
-  const handleLogin = () => {
-    login();
-    navigate('/inicio');
+  const entrar = (usuarioCiudadanoId: string) => {
+    login(usuarioCiudadanoId);
+    // El gate de "/" decide a dónde ir según el perfil (admin o solo ciudadano).
+    navigate('/');
   };
 
   return (
@@ -15,8 +16,7 @@ export default function Login() {
       <div
         className="relative mx-auto flex min-h-screen w-full max-w-md flex-col justify-between overflow-hidden px-7 py-12 text-white"
         style={{
-          backgroundImage:
-            'linear-gradient(165deg,#0f6b45,#138a57,#1bb46f)',
+          backgroundImage: 'linear-gradient(165deg,#0f6b45,#138a57,#1bb46f)',
         }}
       >
         {/* Hero */}
@@ -27,9 +27,6 @@ export default function Login() {
           <h1 className="font-display text-5xl font-extrabold tracking-tight">
             A.R.C.A.
           </h1>
-          <p className="mt-3 text-sm font-medium uppercase tracking-[0.3em] text-green-100">
-            Ciudadano
-          </p>
           <p className="mx-auto mt-6 max-w-xs text-green-50/90">
             Tus voluminosos tienen una segunda vida. Gestión de residuos para
             Santo Domingo.
@@ -39,19 +36,32 @@ export default function Login() {
         {/* CTAs */}
         <div className="space-y-3">
           <button
-            onClick={handleLogin}
+            onClick={() => entrar(DEV_USERS.vecino)}
             className="btn-gold w-full py-4 text-base"
           >
             Ingresar con ClaveÚnica
           </button>
-          <button
-            onClick={handleLogin}
-            className="w-full rounded-pill border border-white/30 py-3 text-sm font-medium text-white/90 transition-colors hover:bg-white/10"
-          >
-            Entrar como vecino (dev)
-          </button>
+
+          {/* Accesos de desarrollo: simulan distintas identidades de ClaveÚnica
+              para probar el login diferido (solo ciudadano vs. doble rol). */}
+          <div className="grid grid-cols-2 gap-2">
+            <button
+              onClick={() => entrar(DEV_USERS.vecino)}
+              className="rounded-pill border border-white/30 py-3 text-sm font-medium text-white/90 transition-colors hover:bg-white/10"
+            >
+              Vecino (dev)
+            </button>
+            <button
+              onClick={() => entrar(DEV_USERS.funcionario)}
+              className="rounded-pill border border-white/30 py-3 text-sm font-medium text-white/90 transition-colors hover:bg-white/10"
+            >
+              Funcionario (dev)
+            </button>
+          </div>
+
           <p className="pt-2 text-center text-xs text-green-100/70">
-            ClaveÚnica + JWT llegará en una fase posterior.
+            ClaveÚnica + JWT llegará en una fase posterior. Tras autenticar, si la
+            persona es funcionaria podrá elegir App ciudadana o Panel municipal.
           </p>
         </div>
       </div>

--- a/apps/frontend/src/pages/Login.tsx
+++ b/apps/frontend/src/pages/Login.tsx
@@ -11,26 +11,49 @@ export default function Login() {
   };
 
   return (
-    <div className="min-h-screen flex items-center justify-center px-4">
-      <div className="w-full max-w-sm bg-white rounded-2xl shadow p-8 text-center">
-        <div className="text-4xl mb-2">🌿</div>
-        <h1 className="text-2xl font-bold text-arca-dark">A.R.C.A.</h1>
-        <p className="text-sm text-gray-500 mb-6">
-          Gestión de residuos · Santo Domingo
-        </p>
+    <div className="flex min-h-screen items-stretch justify-center bg-canvas">
+      <div
+        className="relative mx-auto flex min-h-screen w-full max-w-md flex-col justify-between overflow-hidden px-7 py-12 text-white"
+        style={{
+          backgroundImage:
+            'linear-gradient(165deg,#0f6b45,#138a57,#1bb46f)',
+        }}
+      >
+        {/* Hero */}
+        <div className="mt-16 text-center">
+          <div className="mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-xl bg-white/15 text-4xl backdrop-blur">
+            🌿
+          </div>
+          <h1 className="font-display text-5xl font-extrabold tracking-tight">
+            A.R.C.A.
+          </h1>
+          <p className="mt-3 text-sm font-medium uppercase tracking-[0.3em] text-green-100">
+            Ciudadano
+          </p>
+          <p className="mx-auto mt-6 max-w-xs text-green-50/90">
+            Tus voluminosos tienen una segunda vida. Gestión de residuos para
+            Santo Domingo.
+          </p>
+        </div>
 
-        <button
-          onClick={handleLogin}
-          className="w-full bg-arca-green hover:bg-arca-dark text-white font-medium py-3 rounded-lg transition-colors"
-        >
-          Entrar como vecino (dev)
-        </button>
-
-        <p className="text-xs text-gray-400 mt-4">
-          Login temporal sin autenticación real.
-          <br />
-          ClaveÚnica + JWT llegará en una fase posterior.
-        </p>
+        {/* CTAs */}
+        <div className="space-y-3">
+          <button
+            onClick={handleLogin}
+            className="btn-gold w-full py-4 text-base"
+          >
+            Ingresar con ClaveÚnica
+          </button>
+          <button
+            onClick={handleLogin}
+            className="w-full rounded-pill border border-white/30 py-3 text-sm font-medium text-white/90 transition-colors hover:bg-white/10"
+          >
+            Entrar como vecino (dev)
+          </button>
+          <p className="pt-2 text-center text-xs text-green-100/70">
+            ClaveÚnica + JWT llegará en una fase posterior.
+          </p>
+        </div>
       </div>
     </div>
   );

--- a/apps/frontend/src/pages/MisSolicitudes.tsx
+++ b/apps/frontend/src/pages/MisSolicitudes.tsx
@@ -2,17 +2,19 @@ import { useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
   fetchMisSolicitudes,
+  formatearPrecio,
+  precioReferencial,
   type EstadoSolicitud,
   type SolicitudRetiro,
 } from '../api/arca';
 import { useSession } from '../auth/SessionContext';
 
-const ESTADO_STYLES: Record<EstadoSolicitud, string> = {
-  pendiente: 'bg-yellow-100 text-yellow-800',
-  asignada: 'bg-blue-100 text-blue-800',
-  en_proceso: 'bg-indigo-100 text-indigo-800',
-  completada: 'bg-green-100 text-green-800',
-  cancelada: 'bg-gray-200 text-gray-600',
+const ESTADO_META: Record<EstadoSolicitud, { label: string; cls: string }> = {
+  pendiente: { label: 'Pendiente', cls: 'bg-gold-100 text-gold-600' },
+  asignada: { label: 'Asignada', cls: 'bg-sky-100 text-sky-600' },
+  en_proceso: { label: 'En ruta', cls: 'bg-green-100 text-green-700' },
+  completada: { label: 'Completada', cls: 'bg-green-600 text-white' },
+  cancelada: { label: 'Cancelada', cls: 'bg-line-2 text-slate' },
 };
 
 export default function MisSolicitudes() {
@@ -29,41 +31,60 @@ export default function MisSolicitudes() {
       .finally(() => setLoading(false));
   }, [usuarioCiudadanoId]);
 
-  if (loading) return <p className="text-gray-500">Cargando solicitudes…</p>;
-  if (error) return <p className="text-red-600">{error}</p>;
+  if (loading) return <p className="text-slate">Cargando solicitudes…</p>;
+  if (error) return <p className="text-rose-600">{error}</p>;
 
   return (
-    <div>
-      <h2 className="text-xl font-bold text-arca-dark mb-4">Mis solicitudes</h2>
+    <div className="space-y-4">
+      <header>
+        <h1 className="text-2xl font-extrabold">Mis solicitudes</h1>
+        <p className="text-sm text-slate">Sigue el estado de tus retiros.</p>
+      </header>
 
       {items.length === 0 ? (
-        <div className="bg-white rounded-xl border border-gray-100 p-6 text-center text-gray-500">
-          Aún no tienes solicitudes.{' '}
-          <Link to="/catalogo" className="text-arca-green underline">
-            Ver catálogo
+        <div className="card p-8 text-center">
+          <div className="mx-auto mb-3 flex h-14 w-14 items-center justify-center rounded-full bg-green-50 text-2xl">
+            📋
+          </div>
+          <p className="text-sm text-slate">Aún no tienes solicitudes.</p>
+          <Link to="/solicitar" className="btn-primary mt-4 inline-flex">
+            Solicitar un retiro
           </Link>
         </div>
       ) : (
         <ul className="space-y-3">
-          {items.map((s) => (
-            <li
-              key={s.id}
-              className="bg-white rounded-xl shadow-sm border border-gray-100 p-4 flex items-center justify-between"
-            >
-              <div>
-                <p className="font-medium">Solicitud #{s.id}</p>
-                <p className="text-sm text-gray-500">
-                  {s.residuoCatalogo?.nombre ?? `Residuo #${s.residuoCatalogoId}`}
-                  {s.descripcion ? ` · ${s.descripcion}` : ''}
-                </p>
-              </div>
-              <span
-                className={`text-xs px-2.5 py-1 rounded-full ${ESTADO_STYLES[s.estado]}`}
-              >
-                {s.estado}
-              </span>
-            </li>
-          ))}
+          {items.map((s) => {
+            const meta = ESTADO_META[s.estado];
+            const categoria = s.residuoCatalogo?.categoria;
+            return (
+              <li key={s.id} className="card flex items-center gap-3 p-4">
+                <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-md bg-green-50 text-xl">
+                  ♻️
+                </div>
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center justify-between gap-2">
+                    <p className="truncate font-bold">
+                      {s.residuoCatalogo?.nombre ?? `Residuo #${s.residuoCatalogoId}`}
+                    </p>
+                    <span className={`pill ${meta.cls}`}>{meta.label}</span>
+                  </div>
+                  <p className="truncate text-sm text-slate">
+                    {categoria ? `${categoria} · ` : ''}
+                    {categoria ? formatearPrecio(precioReferencial(categoria)) : ''}
+                    {s.descripcion ? ` · ${s.descripcion}` : ''}
+                  </p>
+                  <p className="text-xs text-slate-2">
+                    {new Date(s.fechaSolicitud).toLocaleDateString('es-CL', {
+                      day: '2-digit',
+                      month: 'short',
+                      hour: '2-digit',
+                      minute: '2-digit',
+                    })}
+                  </p>
+                </div>
+              </li>
+            );
+          })}
         </ul>
       )}
     </div>

--- a/apps/frontend/src/pages/MisSolicitudes.tsx
+++ b/apps/frontend/src/pages/MisSolicitudes.tsx
@@ -1,6 +1,7 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import {
+  cancelarSolicitud,
   fetchMisSolicitudes,
   formatearPrecio,
   precioReferencial,
@@ -17,31 +18,155 @@ const ESTADO_META: Record<EstadoSolicitud, { label: string; cls: string }> = {
   cancelada: { label: 'Cancelada', cls: 'bg-line-2 text-slate' },
 };
 
+// El ciudadano solo puede cancelar si NO está en tránsito ni completada.
+const CANCELABLES: EstadoSolicitud[] = ['pendiente', 'asignada'];
+
+const fechaLarga = (iso: string) =>
+  new Date(iso).toLocaleDateString('es-CL', {
+    day: '2-digit',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
+// Las solicitudes que el ciudadano cancela se ocultan de SU lista (ids por usuario).
+const claveOcultas = (usuarioId: string) => `arca.solicitudesOcultas.${usuarioId}`;
+const leerOcultas = (usuarioId: string): number[] => {
+  try {
+    return JSON.parse(localStorage.getItem(claveOcultas(usuarioId)) ?? '[]');
+  } catch {
+    return [];
+  }
+};
+
 export default function MisSolicitudes() {
   const { usuarioCiudadanoId } = useSession();
   const [items, setItems] = useState<SolicitudRetiro[]>([]);
+  const [ocultas, setOcultas] = useState<number[]>([]);
+  const [seleccion, setSeleccion] = useState<SolicitudRetiro | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [procesando, setProcesando] = useState(false);
 
   useEffect(() => {
     if (!usuarioCiudadanoId) return;
+    setOcultas(leerOcultas(usuarioCiudadanoId));
     fetchMisSolicitudes(usuarioCiudadanoId)
       .then(setItems)
       .catch((e: Error) => setError(e.message))
       .finally(() => setLoading(false));
   }, [usuarioCiudadanoId]);
 
-  if (loading) return <p className="text-slate">Cargando solicitudes…</p>;
-  if (error) return <p className="text-rose-600">{error}</p>;
+  const visibles = useMemo(
+    () => items.filter((s) => !ocultas.includes(s.id)),
+    [items, ocultas],
+  );
 
+  const cancelar = async (id: number) => {
+    if (!usuarioCiudadanoId) return;
+    if (
+      !window.confirm(
+        '¿Cancelar esta solicitud? Dejará de aparecer en tu lista.',
+      )
+    )
+      return;
+
+    setProcesando(true);
+    setError(null);
+    try {
+      await cancelarSolicitud(id, usuarioCiudadanoId, 'Cancelada por el ciudadano');
+      const nuevas = [...leerOcultas(usuarioCiudadanoId), id];
+      localStorage.setItem(claveOcultas(usuarioCiudadanoId), JSON.stringify(nuevas));
+      setOcultas(nuevas);
+      setSeleccion(null);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setProcesando(false);
+    }
+  };
+
+  if (loading) return <p className="text-slate">Cargando solicitudes…</p>;
+
+  // --- Detalle de una solicitud ---------------------------------------------
+  if (seleccion) {
+    const meta = ESTADO_META[seleccion.estado];
+    const categoria = seleccion.residuoCatalogo?.categoria;
+    const puedeCancelar = CANCELABLES.includes(seleccion.estado);
+    return (
+      <div className="space-y-4">
+        <button
+          onClick={() => setSeleccion(null)}
+          className="text-sm text-slate-2 hover:text-ink"
+        >
+          ← Volver
+        </button>
+
+        {error && <p className="text-sm text-rose-600">{error}</p>}
+
+        <div className="card space-y-4 p-5">
+          <div className="flex items-start justify-between gap-2">
+            <div>
+              <h1 className="text-xl font-extrabold">
+                {seleccion.residuoCatalogo?.nombre ??
+                  `Residuo #${seleccion.residuoCatalogoId}`}
+              </h1>
+              {categoria && (
+                <p className="text-sm text-slate">
+                  {categoria} · {formatearPrecio(precioReferencial(categoria))}
+                </p>
+              )}
+            </div>
+            <span className={`pill ${meta.cls}`}>{meta.label}</span>
+          </div>
+
+          <div>
+            <p className="text-xs uppercase tracking-wide text-slate-2">
+              Descripción
+            </p>
+            <p className="mt-1 text-ink">
+              {seleccion.descripcion || 'Sin descripción.'}
+            </p>
+          </div>
+
+          <div>
+            <p className="text-xs uppercase tracking-wide text-slate-2">
+              Solicitada
+            </p>
+            <p className="mt-1 text-ink">{fechaLarga(seleccion.fechaSolicitud)}</p>
+          </div>
+        </div>
+
+        {puedeCancelar ? (
+          <button
+            onClick={() => cancelar(seleccion.id)}
+            disabled={procesando}
+            className="w-full rounded-pill border border-rose-300 py-3 text-sm font-medium text-rose-600 transition-colors hover:bg-rose-50 disabled:opacity-50"
+          >
+            {procesando ? 'Cancelando…' : 'Cancelar solicitud'}
+          </button>
+        ) : (
+          <p className="text-center text-xs text-slate-2">
+            Esta solicitud ya está {meta.label.toLowerCase()} y no se puede cancelar.
+          </p>
+        )}
+      </div>
+    );
+  }
+
+  // --- Listado ---------------------------------------------------------------
   return (
     <div className="space-y-4">
       <header>
         <h1 className="text-2xl font-extrabold">Mis solicitudes</h1>
-        <p className="text-sm text-slate">Sigue el estado de tus retiros.</p>
+        <p className="text-sm text-slate">
+          Toca una solicitud para ver el detalle.
+        </p>
       </header>
 
-      {items.length === 0 ? (
+      {error && <p className="text-sm text-rose-600">{error}</p>}
+
+      {visibles.length === 0 ? (
         <div className="card p-8 text-center">
           <div className="mx-auto mb-3 flex h-14 w-14 items-center justify-center rounded-full bg-green-50 text-2xl">
             📋
@@ -53,35 +178,36 @@ export default function MisSolicitudes() {
         </div>
       ) : (
         <ul className="space-y-3">
-          {items.map((s) => {
+          {visibles.map((s) => {
             const meta = ESTADO_META[s.estado];
             const categoria = s.residuoCatalogo?.categoria;
             return (
-              <li key={s.id} className="card flex items-center gap-3 p-4">
-                <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-md bg-green-50 text-xl">
-                  ♻️
-                </div>
-                <div className="min-w-0 flex-1">
-                  <div className="flex items-center justify-between gap-2">
-                    <p className="truncate font-bold">
-                      {s.residuoCatalogo?.nombre ?? `Residuo #${s.residuoCatalogoId}`}
-                    </p>
-                    <span className={`pill ${meta.cls}`}>{meta.label}</span>
+              <li key={s.id}>
+                <button
+                  onClick={() => {
+                    setError(null);
+                    setSeleccion(s);
+                  }}
+                  className="card flex w-full items-center gap-3 p-4 text-left transition-colors hover:bg-green-50/40"
+                >
+                  <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-md bg-green-50 text-xl">
+                    ♻️
                   </div>
-                  <p className="truncate text-sm text-slate">
-                    {categoria ? `${categoria} · ` : ''}
-                    {categoria ? formatearPrecio(precioReferencial(categoria)) : ''}
-                    {s.descripcion ? ` · ${s.descripcion}` : ''}
-                  </p>
-                  <p className="text-xs text-slate-2">
-                    {new Date(s.fechaSolicitud).toLocaleDateString('es-CL', {
-                      day: '2-digit',
-                      month: 'short',
-                      hour: '2-digit',
-                      minute: '2-digit',
-                    })}
-                  </p>
-                </div>
+                  <div className="min-w-0 flex-1">
+                    <div className="flex items-center justify-between gap-2">
+                      <p className="truncate font-bold">
+                        {s.residuoCatalogo?.nombre ?? `Residuo #${s.residuoCatalogoId}`}
+                      </p>
+                      <span className={`pill ${meta.cls}`}>{meta.label}</span>
+                    </div>
+                    <p className="truncate text-sm text-slate">
+                      {categoria ? `${categoria} · ` : ''}
+                      {categoria ? formatearPrecio(precioReferencial(categoria)) : ''}
+                    </p>
+                    <p className="text-xs text-slate-2">{fechaLarga(s.fechaSolicitud)}</p>
+                  </div>
+                  <span className="text-slate-2">›</span>
+                </button>
               </li>
             );
           })}

--- a/apps/frontend/src/pages/NuevaSolicitud.tsx
+++ b/apps/frontend/src/pages/NuevaSolicitud.tsx
@@ -3,17 +3,20 @@ import { useNavigate, useSearchParams } from 'react-router-dom';
 import {
   crearSolicitudRetiro,
   fetchCatalogo,
+  formatearPrecio,
+  iconoPorCategoria,
+  precioReferencial,
   type ResiduoCatalogo,
 } from '../api/arca';
 import { useSession } from '../auth/SessionContext';
 
 export default function NuevaSolicitud() {
-  const { usuarioCiudadanoId } = useSession();
   const navigate = useNavigate();
+  const { usuarioCiudadanoId } = useSession();
   const [searchParams] = useSearchParams();
 
   const [catalogo, setCatalogo] = useState<ResiduoCatalogo[]>([]);
-  const [residuoCatalogoId, setResiduoCatalogoId] = useState<number | ''>(
+  const [residuoId, setResiduoId] = useState<number | ''>(
     searchParams.get('residuo') ? Number(searchParams.get('residuo')) : '',
   );
   const [descripcion, setDescripcion] = useState('');
@@ -26,18 +29,20 @@ export default function NuevaSolicitud() {
       .catch((e: Error) => setError(e.message));
   }, []);
 
+  const seleccionado = catalogo.find((r) => r.id === residuoId);
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (residuoCatalogoId === '' || !usuarioCiudadanoId) return;
+    if (!seleccionado || !usuarioCiudadanoId) return;
     setSubmitting(true);
     setError(null);
     try {
       await crearSolicitudRetiro({
         usuarioCiudadanoId,
-        residuoCatalogoId: Number(residuoCatalogoId),
+        residuoCatalogoId: seleccionado.id,
         descripcion: descripcion.trim() || undefined,
       });
-      navigate('/mis-solicitudes');
+      navigate('/solicitud/creada');
     } catch (err) {
       setError((err as Error).message);
       setSubmitting(false);
@@ -45,53 +50,67 @@ export default function NuevaSolicitud() {
   };
 
   return (
-    <div className="max-w-lg">
-      <h2 className="text-xl font-bold text-arca-dark mb-4">
-        Nueva solicitud de retiro
-      </h2>
+    <div className="space-y-4">
+      <header>
+        <h1 className="text-2xl font-extrabold">Nueva solicitud</h1>
+        <p className="text-sm text-slate">Confirma el residuo y agrega detalles.</p>
+      </header>
 
-      {error && <p className="text-red-600 mb-3 text-sm">{error}</p>}
+      {error && <p className="pill w-full bg-rose-100 text-rose-600">{error}</p>}
 
-      <form
-        onSubmit={handleSubmit}
-        className="bg-white rounded-xl shadow-sm border border-gray-100 p-5 space-y-4"
-      >
+      <form onSubmit={handleSubmit} className="card space-y-5 p-5">
         <div>
-          <label className="block text-sm font-medium mb-1">Tipo de residuo</label>
+          <label className="mb-1.5 block text-sm font-semibold">
+            Tipo de residuo
+          </label>
           <select
-            value={residuoCatalogoId}
+            value={residuoId}
             onChange={(e) =>
-              setResiduoCatalogoId(e.target.value ? Number(e.target.value) : '')
+              setResiduoId(e.target.value ? Number(e.target.value) : '')
             }
             required
-            className="w-full border border-gray-300 rounded-lg px-3 py-2"
+            className="field"
           >
-            <option value="">Selecciona…</option>
+            <option value="">Selecciona del catálogo…</option>
             {catalogo.map((item) => (
               <option key={item.id} value={item.id}>
-                {item.nombre} — {item.categoria}
+                {item.nombre} — {item.categoria} (
+                {formatearPrecio(precioReferencial(item.categoria))})
               </option>
             ))}
           </select>
         </div>
 
+        {/* Resumen de precio del seleccionado */}
+        {seleccionado && (
+          <div className="flex items-center justify-between rounded-md bg-green-50 px-4 py-3">
+            <span className="flex items-center gap-2 text-sm font-medium">
+              <span className="text-xl">{iconoPorCategoria(seleccionado.categoria)}</span>
+              {seleccionado.nombre}
+            </span>
+            <span className="font-display text-lg font-extrabold text-green-700">
+              {formatearPrecio(precioReferencial(seleccionado.categoria))}
+            </span>
+          </div>
+        )}
+
         <div>
-          <label className="block text-sm font-medium mb-1">
-            Descripción (opcional)
+          <label className="mb-1.5 block text-sm font-semibold">
+            Descripción <span className="font-normal text-slate-2">(opcional)</span>
           </label>
           <textarea
             value={descripcion}
             onChange={(e) => setDescripcion(e.target.value)}
             rows={3}
             placeholder="Ej: Sofá usado en buen estado"
-            className="w-full border border-gray-300 rounded-lg px-3 py-2"
+            className="field resize-none"
           />
         </div>
 
         <button
           type="submit"
-          disabled={submitting || residuoCatalogoId === ''}
-          className="w-full bg-arca-green hover:bg-arca-dark disabled:opacity-50 text-white font-medium py-2.5 rounded-lg transition-colors"
+          disabled={submitting || !seleccionado}
+          className="btn-primary w-full py-3.5"
         >
           {submitting ? 'Enviando…' : 'Crear solicitud'}
         </button>

--- a/apps/frontend/src/pages/Proximamente.tsx
+++ b/apps/frontend/src/pages/Proximamente.tsx
@@ -1,0 +1,32 @@
+import { useNavigate } from 'react-router-dom';
+
+interface Props {
+  titulo: string;
+  descripcion: string;
+  icono: string;
+  epica: string;
+}
+
+// Placeholder estético para módulos sin flujo de backend todavía.
+export default function Proximamente({ titulo, descripcion, icono, epica }: Props) {
+  const navigate = useNavigate();
+  return (
+    <div className="space-y-5">
+      <header>
+        <h1 className="text-2xl font-extrabold">{titulo}</h1>
+      </header>
+
+      <div className="card flex flex-col items-center gap-4 p-8 text-center">
+        <div className="flex h-20 w-20 items-center justify-center rounded-full bg-green-50 text-4xl">
+          {icono}
+        </div>
+        <span className="pill bg-line-2 text-slate">Próximamente · {epica}</span>
+        <p className="max-w-xs text-sm text-slate">{descripcion}</p>
+      </div>
+
+      <button onClick={() => navigate('/inicio')} className="btn-outline w-full">
+        Volver al inicio
+      </button>
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/SeleccionInicio.tsx
+++ b/apps/frontend/src/pages/SeleccionInicio.tsx
@@ -1,0 +1,69 @@
+import { useNavigate } from 'react-router-dom';
+
+export default function SeleccionInicio() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex min-h-screen items-stretch justify-center bg-canvas">
+      <div
+        className="relative mx-auto flex min-h-screen w-full max-w-md flex-col justify-between overflow-hidden px-7 py-12 text-white"
+        style={{
+          backgroundImage: 'linear-gradient(165deg,#0f6b45,#138a57,#1bb46f)',
+        }}
+      >
+        {/* Hero */}
+        <div className="mt-16 text-center">
+          <div className="mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-xl bg-white/15 text-4xl backdrop-blur">
+            🌿
+          </div>
+          <h1 className="font-display text-5xl font-extrabold tracking-tight">
+            A.R.C.A.
+          </h1>
+          <p className="mx-auto mt-6 max-w-xs text-green-50/90">
+            Gestión de residuos voluminosos para Santo Domingo. Elige cómo
+            quieres ingresar.
+          </p>
+        </div>
+
+        {/* Selección de portal */}
+        <div className="space-y-3">
+          <button
+            onClick={() => navigate('/login')}
+            className="flex w-full items-center gap-4 rounded-2xl bg-white/10 p-4 text-left backdrop-blur transition-colors hover:bg-white/15"
+          >
+            <span className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-white/15 text-2xl">
+              📱
+            </span>
+            <span>
+              <span className="block text-base font-bold">App ciudadana</span>
+              <span className="block text-sm text-green-50/80">
+                Solicita y sigue tus retiros (PWA)
+              </span>
+            </span>
+          </button>
+
+          <button
+            onClick={() => navigate('/admin')}
+            className="flex w-full items-center gap-4 rounded-2xl bg-white/10 p-4 text-left backdrop-blur transition-colors hover:bg-white/15"
+          >
+            <span className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-white/15 text-2xl">
+              🏛️
+            </span>
+            <span>
+              <span className="block text-base font-bold">
+                Portal administrativo
+              </span>
+              <span className="block text-sm text-green-50/80">
+                Revisa y gestiona las solicitudes municipales
+              </span>
+            </span>
+          </button>
+
+          <p className="pt-2 text-center text-xs text-green-100/70">
+            ClaveÚnica + JWT llegará en una fase posterior.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/SeleccionInicio.tsx
+++ b/apps/frontend/src/pages/SeleccionInicio.tsx
@@ -1,7 +1,10 @@
 import { useNavigate } from 'react-router-dom';
+import { useSession } from '../auth/SessionContext';
 
 export default function SeleccionInicio() {
   const navigate = useNavigate();
+  const { perfil, logout } = useSession();
+  const nombre = perfil?.administrador?.nombre;
 
   return (
     <div className="flex min-h-screen items-stretch justify-center bg-canvas">
@@ -16,28 +19,27 @@ export default function SeleccionInicio() {
           <div className="mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-xl bg-white/15 text-4xl backdrop-blur">
             🌿
           </div>
-          <h1 className="font-display text-5xl font-extrabold tracking-tight">
-            A.R.C.A.
+          <h1 className="font-display text-4xl font-extrabold tracking-tight">
+            {nombre ? `Hola, ${nombre}` : 'A.R.C.A.'}
           </h1>
-          <p className="mx-auto mt-6 max-w-xs text-green-50/90">
-            Gestión de residuos voluminosos para Santo Domingo. Elige cómo
-            quieres ingresar.
+          <p className="mx-auto mt-4 max-w-xs text-green-50/90">
+            Tu cuenta es municipal. ¿Con qué contexto quieres entrar?
           </p>
         </div>
 
-        {/* Selección de portal */}
+        {/* Selección de contexto */}
         <div className="space-y-3">
           <button
-            onClick={() => navigate('/login')}
+            onClick={() => navigate('/inicio')}
             className="flex w-full items-center gap-4 rounded-2xl bg-white/10 p-4 text-left backdrop-blur transition-colors hover:bg-white/15"
           >
             <span className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-white/15 text-2xl">
               📱
             </span>
             <span>
-              <span className="block text-base font-bold">App ciudadana</span>
+              <span className="block text-base font-bold">Modo vecino</span>
               <span className="block text-sm text-green-50/80">
-                Solicita y sigue tus retiros (PWA)
+                App ciudadana: solicita y sigue tus retiros
               </span>
             </span>
           </button>
@@ -50,18 +52,19 @@ export default function SeleccionInicio() {
               🏛️
             </span>
             <span>
-              <span className="block text-base font-bold">
-                Portal administrativo
-              </span>
+              <span className="block text-base font-bold">Modo funcionario</span>
               <span className="block text-sm text-green-50/80">
-                Revisa y gestiona las solicitudes municipales
+                Panel municipal: revisa y gestiona solicitudes
               </span>
             </span>
           </button>
 
-          <p className="pt-2 text-center text-xs text-green-100/70">
-            ClaveÚnica + JWT llegará en una fase posterior.
-          </p>
+          <button
+            onClick={logout}
+            className="w-full pt-2 text-center text-xs text-green-100/70 hover:text-white"
+          >
+            Cerrar sesión
+          </button>
         </div>
       </div>
     </div>

--- a/apps/frontend/src/pages/SolicitudCreada.tsx
+++ b/apps/frontend/src/pages/SolicitudCreada.tsx
@@ -1,0 +1,53 @@
+import { useNavigate } from 'react-router-dom';
+import { useSolicitudFlow } from '../flow/SolicitudFlow';
+
+export default function SolicitudCreada() {
+  const navigate = useNavigate();
+  const { reset } = useSolicitudFlow();
+
+  // Salir del flujo limpia la foto efímera.
+  const irA = (ruta: string) => {
+    reset();
+    navigate(ruta);
+  };
+
+  return (
+    <div className="flex flex-col items-center gap-6 py-4 text-center">
+      {/* SuccessRing dorado */}
+      <div className="success-ring mt-4 flex h-28 w-28 items-center justify-center rounded-full bg-gold-50 text-5xl">
+        ✅
+      </div>
+
+      <header>
+        <h1 className="text-2xl font-extrabold">¡Solicitud creada!</h1>
+        <p className="mt-1 text-sm text-slate">
+          Tu retiro quedó registrado. Te avisaremos cuando sea agendado.
+        </p>
+      </header>
+
+      <span className="pill bg-gold-100 text-gold-600">+5 Circular Credits</span>
+
+      <div className="w-full space-y-3 pt-2">
+        <p className="text-sm font-semibold text-slate">¿Qué quieres hacer ahora?</p>
+        <button
+          onClick={() => irA('/retiro-municipal')}
+          className="btn-primary w-full py-3.5"
+        >
+          Registrar retiro municipal
+        </button>
+        <button
+          onClick={() => irA('/marketplace/subir')}
+          className="btn-gold w-full py-3.5"
+        >
+          ♻️ Subir al Marketplace
+        </button>
+        <button
+          onClick={() => irA('/mis-solicitudes')}
+          className="btn-ghost w-full"
+        >
+          Ver mis solicitudes
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/pages/SugerenciasIA.tsx
+++ b/apps/frontend/src/pages/SugerenciasIA.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  fetchCatalogo,
+  formatearPrecio,
+  iconoPorCategoria,
+  precioReferencial,
+  type ResiduoCatalogo,
+} from '../api/arca';
+import { useSolicitudFlow } from '../flow/SolicitudFlow';
+
+// Confianza simulada — la IA real (TensorFlow.js) llega en una fase posterior.
+const CONFIANZA_MOCK = 92;
+
+export default function SugerenciasIA() {
+  const navigate = useNavigate();
+  const { fotoPreview } = useSolicitudFlow();
+  const [sugerencia, setSugerencia] = useState<ResiduoCatalogo | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    // "Detección" mock: tomamos un residuo reutilizable real del catálogo.
+    fetchCatalogo()
+      .then((items) => {
+        setSugerencia(items.find((i) => i.puedeReutilizarse) ?? items[0] ?? null);
+      })
+      .catch((e: Error) => setError(e.message));
+  }, []);
+
+  if (error) return <p className="text-rose-600">{error}</p>;
+  if (!sugerencia) return <p className="text-slate">Procesando resultado…</p>;
+
+  return (
+    <div className="space-y-5">
+      <header>
+        <h1 className="text-2xl font-extrabold">Resultado</h1>
+        <p className="text-sm text-slate">Esto detectamos en tu foto.</p>
+      </header>
+
+      {/* Tarjeta de detección */}
+      <div className="card overflow-hidden">
+        {fotoPreview ? (
+          <img src={fotoPreview} alt="Residuo" className="h-40 w-full object-cover" />
+        ) : (
+          <div className="flex h-40 w-full items-center justify-center bg-green-50 text-6xl">
+            {iconoPorCategoria(sugerencia.categoria)}
+          </div>
+        )}
+        <div className="p-4">
+          <div className="flex items-center justify-between">
+            <span className="pill bg-green-100 text-green-700">
+              IA · {CONFIANZA_MOCK}% confianza
+            </span>
+            {sugerencia.puedeReutilizarse && (
+              <span className="pill bg-gold-100 text-gold-600">Reutilizable</span>
+            )}
+          </div>
+          <h2 className="mt-3 text-xl font-extrabold">{sugerencia.nombre}</h2>
+          <p className="text-sm text-slate">
+            {sugerencia.categoria} ·{' '}
+            {formatearPrecio(precioReferencial(sugerencia.categoria))}
+          </p>
+          {/* Barra de confianza */}
+          <div className="mt-3 h-2 overflow-hidden rounded-pill bg-line-2">
+            <div
+              className="h-full rounded-pill bg-green-500"
+              style={{ width: `${CONFIANZA_MOCK}%` }}
+            />
+          </div>
+        </div>
+      </div>
+
+      <p className="text-center text-sm text-slate">
+        ¿Es correcto? Continúa con la sugerencia o ingrésalo a mano.
+      </p>
+
+      <div className="space-y-3">
+        <button
+          onClick={() => navigate(`/nueva-solicitud?residuo=${sugerencia.id}`)}
+          className="btn-primary w-full py-3.5"
+        >
+          Usar sugerencia del catálogo
+        </button>
+        <button
+          onClick={() => navigate('/nueva-solicitud')}
+          className="btn-outline w-full"
+        >
+          Ingresar detalles manualmente
+        </button>
+        <button onClick={() => navigate('/solicitar')} className="btn-ghost w-full">
+          Repetir foto
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/tailwind.config.js
+++ b/apps/frontend/tailwind.config.js
@@ -1,14 +1,60 @@
 /** @type {import('tailwindcss').Config} */
+// Sistema de diseño A.R.C.A. — tokens espejados del UI Kit v1.0.
+// Mantener sincronizado con docs/UI_KIT.md y los standalone de referencia.
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {
       colors: {
-        arca: {
-          green: '#2f9e44',
-          dark: '#1b4332',
-          light: '#d8f3dc',
+        // Escala verde — primario de la marca (Circular Green)
+        green: {
+          50: '#eff9f3',
+          100: '#ddf3e8',
+          200: '#b6ebcf',
+          300: '#7ed9ab',
+          500: '#1bb46f',
+          600: '#138a57',
+          700: '#0F6B45',
+          800: '#0E5238',
+          900: '#0A3D29',
         },
+        // Dorado — Circular Credits / CTA de reutilización
+        gold: {
+          50: '#fef7e9',
+          100: '#fdeccc',
+          400: '#f7b54e',
+          500: '#ef9d24',
+          600: '#c97e12',
+        },
+        rose: { 100: '#fbe2dc', 600: '#c4452f' }, // alertas
+        sky: { 100: '#d9eef9', 600: '#1f7fb8' }, // info
+        // Neutros verdosos
+        ink: { DEFAULT: '#0e1a14', 2: '#2b3a32' },
+        slate: { DEFAULT: '#5d6e64', 2: '#8a988f' },
+        line: { DEFAULT: '#e6ece8', 2: '#eef2ef' },
+        canvas: '#f3f6f3',
+        card: { DEFAULT: '#ffffff', 2: '#f8faf8' },
+        side: '#0c3526',
+        // Alias de compatibilidad con clases arca-* previas
+        arca: { green: '#138a57', dark: '#0F6B45', light: '#ddf3e8' },
+      },
+      fontFamily: {
+        display: ["'Bricolage Grotesque'", 'system-ui', 'sans-serif'],
+        body: ["'Hanken Grotesk'", 'system-ui', 'sans-serif'],
+      },
+      borderRadius: {
+        sm: '12px',
+        md: '18px',
+        lg: '24px',
+        xl: '30px',
+        pill: '999px',
+      },
+      boxShadow: {
+        sm: '0 1px 2px rgba(14,26,20,.05),0 1px 3px rgba(14,26,20,.04)',
+        md: '0 4px 14px rgba(14,26,20,.07),0 1px 4px rgba(14,26,20,.05)',
+        lg: '0 12px 34px rgba(14,26,20,.12),0 4px 12px rgba(14,26,20,.06)',
+        green: '0 8px 22px rgba(19,138,87,.28)',
+        gold: '0 8px 20px rgba(239,157,36,.30)',
       },
     },
   },

--- a/docs/BACKEND_FASE1.md
+++ b/docs/BACKEND_FASE1.md
@@ -1,7 +1,7 @@
 # Backend Fase 1 — Resumen de implementación
 
 > **Autor:** Javier Figueroa (Back-End)  
-> **Rama:** `feature/backend`  
+> **Integrado en:** `develop` / `master` (el trabajo se hizo en la antigua `feature/backend`, ya eliminada)  
 > **Fecha:** Junio 2026  
 > **Equipo:** COM Tech — Feria de Software 2026
 

--- a/docs/BACKEND_FASE1.md
+++ b/docs/BACKEND_FASE1.md
@@ -65,6 +65,7 @@ A.R.C.A/
 | `1782163200000-create-identity-tables` | `usuarios_ciudadanos`, `sesiones_ciudadano`, `usuarios_administradores`, `sesiones_administrador` |
 | `1782163300000-create-residuos-catalogo` | `residuos_catalogo` + seed (Sofá, Refrigerador, Colchón, Escombros) |
 | `1782163400000-create-solicitudes-retiro` | `solicitudes_retiro` + usuario dev de prueba |
+| `1782163500000-seed-operador-demo` | Usuario demo **doble rol** (ciudadano `…0002` + operador `…00A2`) |
 
 **Comando:** `npm run migration:run` (desde `apps/backend/`)
 
@@ -92,6 +93,21 @@ Base URL local: `http://localhost:3000`
 | `POST` | `/solicitudes-retiro` | Crear solicitud de retiro |
 | `GET` | `/solicitudes-retiro` | Listar solicitudes |
 | `GET` | `/solicitudes-retiro?usuarioCiudadanoId={uuid}` | Solicitudes de un ciudadano |
+| `GET` | `/solicitudes-retiro?estado={estado}` | Filtrar por estado (vista admin) |
+| `GET` | `/solicitudes-retiro/{id}` | Detalle (ciudadano + residuo + operador) |
+| `PATCH` | `/solicitudes-retiro/{id}` | **Admin:** modificar estado/operador/fecha/razón |
+| `PATCH` | `/solicitudes-retiro/{id}/cancelar` | **Ciudadano:** cancelar su propia solicitud |
+
+### Máquina de estados (PATCH admin)
+
+Transiciones válidas: `pendiente → asignada → en_proceso → completada`; cualquier estado
+activo puede ir a `cancelada`. El backend valida:
+
+- `asignada` exige `operadorAsignadoId` de un administrador **activo**.
+- `cancelada` exige `razonRechazo`.
+- `completada` setea `fechaCompletada` automáticamente.
+- La cancelación del ciudadano solo procede sobre **sus** solicitudes en estado
+  `pendiente` o `asignada` (valida propiedad → `403` si es ajena).
 
 ### Ejemplo POST solicitud
 
@@ -115,6 +131,15 @@ Hasta que Benjamín integre auth (JWT / ClaveÚnica), existe un ciudadano de pru
 |---|---|
 | `id` | `00000000-0000-4000-8000-000000000001` |
 | `clave_unica_id` | `dev-claveunica-test` |
+
+Además, la migración `seed-operador-demo` agrega un **usuario demo con doble rol** (misma
+persona como ciudadano y como operador municipal), para poder ejercitar el ciclo admin
+completo `asignar → en_proceso → completada`:
+
+| Campo | Valor |
+|---|---|
+| Ciudadano (identidad base) | `00000000-0000-4000-8000-000000000002` |
+| Operador (`operadorAsignadoId`) | `00000000-0000-4000-8000-0000000000A2` · rol `operador` |
 
 **No usar en producción.** Cuando auth esté listo, el `usuarioCiudadanoId` saldrá del token JWT, no del body.
 
@@ -149,11 +174,12 @@ d44f15f feat(backend): entidades TypeORM de identidad y UsersModule
 | Área | Responsable | Notas |
 |---|---|---|
 | Auth ClaveÚnica + JWT | Benjamín (`feature/auth`) | Requiere aprobación organismo gubernamental |
-| Auth mock / guards | Benjamín | Puede avanzar con entidades de `users/` |
+| Auth mock / guards | Benjamín | Pendiente: proteger `/admin` y PATCH por rol |
 | Frontend React PWA | Maximiliano (`feature/frontend`) | Ver `docs/SETUP_LOCAL.md` |
 | Migraciones restantes del DBML | Javier | horarios, fotos, marketplace, credits, etc. |
 | Subida de fotos | Javier | Fase posterior |
-| PATCH estado solicitud (operador) | Javier | Dashboard / operadores |
+| ~~PATCH estado solicitud (operador)~~ | ✅ Hecho | Rama `admin-municipal` (máquina de estados) |
+| ~~Cancelación por ciudadano~~ | ✅ Hecho | Rama `admin-municipal` (`PATCH /:id/cancelar`) |
 | PR merge a `develop` | Javier | Integración con el equipo |
 
 ---

--- a/docs/BACKEND_FASE1.md
+++ b/docs/BACKEND_FASE1.md
@@ -97,17 +97,27 @@ Base URL local: `http://localhost:3000`
 | `GET` | `/solicitudes-retiro/{id}` | Detalle (ciudadano + residuo + operador) |
 | `PATCH` | `/solicitudes-retiro/{id}` | **Admin:** modificar estado/operador/fecha/razón |
 | `PATCH` | `/solicitudes-retiro/{id}/cancelar` | **Ciudadano:** cancelar su propia solicitud |
+| `GET` | `/usuarios/{ciudadanoId}/perfil-acceso` | Login diferido: `{ esAdministrador, administrador }` |
 
-### Máquina de estados (PATCH admin)
+### Cambio de estado (PATCH admin)
 
-Transiciones válidas: `pendiente → asignada → en_proceso → completada`; cualquier estado
-activo puede ir a `cancelada`. El backend valida:
+El panel municipal puede fijar **cualquier** estado, incluido **revertir** (ej.
+`completada → pendiente`), para operar y probar el flujo. El backend solo conserva
+invariantes de datos:
 
 - `asignada` exige `operadorAsignadoId` de un administrador **activo**.
-- `cancelada` exige `razonRechazo`.
-- `completada` setea `fechaCompletada` automáticamente.
+- `completada` setea `fechaCompletada`; al **salir** de completada se limpia.
 - La cancelación del ciudadano solo procede sobre **sus** solicitudes en estado
   `pendiente` o `asignada` (valida propiedad → `403` si es ajena).
+
+> Nota: la máquina de estados estricta (`pendiente→asignada→en_proceso→completada`)
+> se relajó a propósito para esta fase. Endurecerla queda como pendiente (flag/permiso).
+
+### Login diferido
+
+`GET /usuarios/{ciudadanoId}/perfil-acceso` resuelve si una identidad base además
+tiene extensión de administrador activa. El frontend lo usa tras autenticar para
+decidir el destino: funcionario → selección de contexto; solo ciudadano → PWA directa.
 
 ### Ejemplo POST solicitud
 
@@ -180,6 +190,8 @@ d44f15f feat(backend): entidades TypeORM de identidad y UsersModule
 | Subida de fotos | Javier | Fase posterior |
 | ~~PATCH estado solicitud (operador)~~ | ✅ Hecho | Rama `admin-municipal` (máquina de estados) |
 | ~~Cancelación por ciudadano~~ | ✅ Hecho | Rama `admin-municipal` (`PATCH /:id/cancelar`) |
+| ~~Login diferido (perfil-acceso)~~ | ✅ Hecho | `GET /usuarios/:id/perfil-acceso` |
+| Endurecer máquina de estados | Pendiente | Hoy reversible para pruebas; reponer con flag/permiso |
 | PR merge a `develop` | Javier | Integración con el equipo |
 
 ---

--- a/docs/FRONTEND_FASE1.md
+++ b/docs/FRONTEND_FASE1.md
@@ -277,8 +277,9 @@ los endpoints correspondientes.
 | EP-02 Marketplace | Listado/publicación, chat en tiempo real (`socket.io-client`), ratings |
 | EP-04 Circular Credits | Saldo + historial en perfil |
 | EP-03 Dashboard municipal | ✅ Base hecha (`/admin`: listar/filtrar/detalle + estados, rama `admin-municipal`). Falta panel funcionario completo, mapa de calor (**Leaflet** + OpenStreetMap), reportes |
-| Inicio diferido | ✅ Hecho (`/`): selector App ciudadana / Portal admin |
-| Proteger `/admin` | Pendiente: el panel está abierto hasta que existan guards/JWT |
+| Login diferido | ✅ Hecho: ClaveÚnica primero (`/login`) → gate `/` decide por `perfil-acceso` |
+| Proteger `/admin` | ✅ `RequireAdmin` en el front (solo funcionarios). Falta guard real con JWT en backend |
+| Cancelar desde detalle (ciudadano) | ✅ Mis solicitudes: tocar → detalle → cancelar; oculta local |
 | Tests | Vitest + React Testing Library |
 
 ---

--- a/docs/FRONTEND_FASE1.md
+++ b/docs/FRONTEND_FASE1.md
@@ -1,6 +1,6 @@
 # Frontend Fase 1 — Resumen de implementación
 
-> **Rama:** `feature/frontend`
+> **Integrado en:** `develop` / `master` (el trabajo se hizo en la antigua `feature/frontend`, ya eliminada)
 > **Fecha:** Junio 2026
 > **Equipo:** COM Tech — Feria de Software 2026
 
@@ -144,11 +144,11 @@ cambiar `activo: false → true` y completar `ruta`. **`Inicio.tsx` no se modifi
 
 ### Pasos
 ```bash
-# 1. Clonar y ubicarse en la rama de frontend
+# 1. Clonar y ubicarse en develop (rama de trabajo)
 git clone https://github.com/blindjamin/A.R.C.A.git
 cd A.R.C.A
-git checkout feature/frontend
-git pull origin feature/frontend
+git checkout develop
+git pull origin develop
 
 # 2. Instalar dependencias del frontend
 cd apps/frontend

--- a/docs/FRONTEND_FASE1.md
+++ b/docs/FRONTEND_FASE1.md
@@ -1,10 +1,10 @@
 # Frontend Fase 1 — Resumen de implementación
 
-> **Integrado en:** `develop` / `master` (el trabajo se hizo en la antigua `feature/frontend`, ya eliminada)
-> **Fecha:** Junio 2026
+> **Integrado en:** `develop` (rama de trabajo `mvp`)
+> **Última actualización:** 2026-06-24
 > **Equipo:** COM Tech — Feria de Software 2026
 
-Documento de hito que resume la primera implementación del frontend (PWA ciudadana) y
+Documento de hito que resume la implementación del frontend (PWA ciudadana) y
 sirve como **base para la documentación futura** del módulo. A medida que se agreguen
 pantallas y épicas, extender las secciones correspondientes.
 
@@ -13,10 +13,13 @@ pantallas y épicas, extender las secciones correspondientes.
 ## Objetivo de esta fase
 
 Montar la **base del frontend (Fase 1)** consumiendo exactamente lo que el backend ya
-expone (épica **EP-01**), con un flujo ciudadano de punta a punta:
+expone (épica **EP-01**), con estética alineada a los prototipos oficiales y un flujo
+ciudadano de punta a punta:
 
 - App PWA React conectada a la API NestJS local
-- Flujo: ver catálogo → crear solicitud de retiro → seguir mis solicitudes
+- **Sistema de diseño A.R.C.A.** (UI Kit v1.0) aplicado: tokens, tipografía, shell mobile
+- Flujo "Solicitar retiro" con **esqueleto de IA** (captura → análisis → sugerencia → éxito)
+- Catálogo, creación y seguimiento de solicitudes contra el backend real
 - **Login temporal** mientras no exista autenticación real (ClaveÚnica/JWT)
 
 ---
@@ -27,16 +30,32 @@ expone (épica **EP-01**), con un flujo ciudadano de punta a punta:
 |---|---|---|
 | Framework | React 18 + TypeScript | |
 | Build/dev | Vite | dev server en `http://localhost:5173` |
-| Estilos | Tailwind CSS **v3** | ⚠️ Ver nota de desviación abajo |
+| Estilos | Tailwind CSS **v3** | tokens del UI Kit en `tailwind.config.js` |
 | Ruteo | react-router-dom | rutas protegidas por sesión |
-| Estado/API | `fetch` nativo (sin Redux aún) | migrar a Redux Toolkit cuando crezca el estado |
+| Estado/API | `fetch` nativo + Context | migrar a Redux Toolkit cuando crezca el estado |
 
-> **⚠️ Desviación a confirmar con el equipo:** el stack documentado (`CLAUDE_proyecto.md`
-> §4.1, `UI_KIT_ARCA.md`) especifica **Tailwind v4**. En esta fase se usó **Tailwind v3**
-> por simplicidad de configuración (`tailwind.config.js` + `postcss.config.js` clásicos).
-> Migrar a v4 es directo si el equipo lo prefiere. Igual está pendiente aplicar el UI Kit
-> oficial (colores `#1A3D2B`/`#52B788`, fuente Inter, lucide-react); por ahora se usó una
-> paleta verde provisional (`arca.*` en `tailwind.config.js`).
+---
+
+## Sistema de diseño (UI Kit v1.0)
+
+Tokens espejados de los standalone de referencia (`ARCA UI Kit` / `ARCA Prototipo`) en
+[`tailwind.config.js`](../apps/frontend/tailwind.config.js), con clases reutilizables en
+[`index.css`](../apps/frontend/src/index.css).
+
+| Token | Valor |
+|---|---|
+| Tipografía | Bricolage Grotesque (display) · Hanken Grotesk (body) |
+| Verde (primario) | escala `green-50…900` (`700 #0F6B45`) |
+| Dorado (Circular Credits) | `gold-50…600` (`500 #ef9d24`) |
+| Rose / Sky | alertas / info |
+| Neutros | `ink`, `slate`, `line`, `canvas #f3f6f3` |
+| Radios | `sm 12 · md 18 · lg 24 · xl 30 · pill` |
+| Sombras | `sm/md/lg` + glows `green`/`gold` |
+
+Clases listas: `.card`, `.btn-primary/-gold/-outline/-ghost`, `.pill`, `.field`, `.chip`.
+
+**Shell mobile:** columna `max-w-md` centrada sobre canvas (emula el frame del prototipo),
+header sticky con marca, **TabBar inferior** (Inicio · Solicitar · Solicitudes).
 
 ---
 
@@ -45,24 +64,31 @@ expone (épica **EP-01**), con un flujo ciudadano de punta a punta:
 ```
 apps/frontend/
 ├── .env.local                  # VITE_API_URL=http://localhost:3000 (no versionado)
-├── tailwind.config.js          # config Tailwind + paleta arca provisional
+├── tailwind.config.js          # tokens del UI Kit (colores, fuentes, radios, sombras)
 ├── postcss.config.js
 └── src/
     ├── main.tsx                # entrypoint
-    ├── App.tsx                 # router + layout + ruta protegida (RequireSession)
-    ├── index.css               # directivas Tailwind
+    ├── App.tsx                 # router + shell mobile + TabBar + ruta protegida
+    ├── index.css               # base + clases de componentes + animaciones (scan/success)
     ├── api/
-    │   └── arca.ts             # capa fetch tipada + interfaces del dominio
+    │   └── arca.ts             # capa fetch tipada + overlay de precio/ícono por categoría
     ├── auth/
     │   └── SessionContext.tsx  # login temporal (usuario dev en localStorage)
+    ├── flow/
+    │   └── SolicitudFlow.tsx   # estado efímero del flujo (foto capturada)
     ├── config/
     │   └── modulos.ts          # registro de módulos del Inicio (fuente de verdad del menú)
     └── pages/
-        ├── Login.tsx
-        ├── Inicio.tsx          # hub post-login: grid de módulos
+        ├── Login.tsx              # hero verde + CTA dorado ClaveÚnica
+        ├── Inicio.tsx            # dashboard: tarjeta de impacto (demo) + grid de módulos
+        ├── CapturaResiduo.tsx    # cámara/galería (solo visual)
+        ├── AnalizandoIA.tsx      # scan animado mock (~2.2s)
+        ├── SugerenciasIA.tsx     # detección mock sobre catálogo real
         ├── Catalogo.tsx
         ├── NuevaSolicitud.tsx
-        └── MisSolicitudes.tsx
+        ├── SolicitudCreada.tsx   # SuccessRing + CTAs (retiro / marketplace)
+        ├── MisSolicitudes.tsx
+        └── Proximamente.tsx      # placeholder reutilizable (retiro municipal, marketplace)
 ```
 
 ---
@@ -81,6 +107,19 @@ Expone funciones tipadas e interfaces del dominio (`ResiduoCatalogo`, `Solicitud
 
 > Cuando se integre Redux Toolkit (roadmap), esta capa se reemplaza por slices/endpoints
 > de RTK Query. Las pantallas deberían cambiar poco si se mantiene la misma firma.
+
+### Overlay de precio e ícono (provisional)
+
+La entidad `ResiduoCatalogo` del backend **no tiene `precio` ni `icono`**. Para mostrar
+ambos en la UI, `arca.ts` deriva valores **referenciales por categoría**:
+
+| Helper | Qué hace |
+|---|---|
+| `precioReferencial(categoria)` | precio CLP por categoría (Muebles, Electrónica, …) |
+| `iconoPorCategoria(categoria)` | emoji por categoría |
+| `formatearPrecio(clp)` | formato `es-CL` (`$8.000`) |
+
+> **Pendiente:** agregar columna `precio` a la entidad + migración, y quitar el overlay.
 
 ---
 
@@ -101,19 +140,41 @@ de `login()` (guardar token, derivar el id del token) y se deja de enviar
 
 ## Pantallas (`src/pages/`)
 
-| Pantalla | Ruta | Endpoint | HU relacionada |
+| Pantalla | Ruta | Endpoint / datos | Tipo |
 |---|---|---|---|
-| `Login` | `/login` | — | HU-12 (placeholder) |
-| `Inicio` | `/inicio` | — | hub de navegación |
-| `Catalogo` | `/catalogo` | `GET /residuos/catalogo` | HU-01 |
-| `NuevaSolicitud` | `/nueva-solicitud` | `POST /solicitudes-retiro` | HU-01 |
-| `MisSolicitudes` | `/mis-solicitudes` | `GET /solicitudes-retiro?usuarioCiudadanoId=` | HU-03 |
+| `Login` | `/login` | — | placeholder |
+| `Inicio` | `/inicio` | tarjeta de impacto **demo** | hub |
+| `CapturaResiduo` | `/solicitar` | cámara/galería (solo visual) | esqueleto |
+| `AnalizandoIA` | `/solicitar/analizando` | scan mock (~2.2s) | esqueleto |
+| `SugerenciasIA` | `/solicitar/sugerencias` | `GET /residuos/catalogo` (detección mock) | esqueleto |
+| `Catalogo` | `/catalogo` | `GET /residuos/catalogo` | **backend** |
+| `NuevaSolicitud` | `/nueva-solicitud` | `POST /solicitudes-retiro` | **backend** |
+| `SolicitudCreada` | `/solicitud/creada` | SuccessRing + 2 CTAs | esqueleto |
+| `MisSolicitudes` | `/mis-solicitudes` | `GET /solicitudes-retiro?usuarioCiudadanoId=` | **backend** |
+| `Proximamente` | `/retiro-municipal`, `/marketplace/subir` | — | placeholder |
 
 - Las rutas (salvo `/login`) están envueltas en `RequireSession`: sin sesión → redirige a `/login`.
 - **Tras el login se cae en `/inicio`** (el hub); el catch-all `*` también redirige ahí.
 - Estados de carga/error manejados localmente con `useState`.
-- `Catalogo` enlaza a `NuevaSolicitud` pre-seleccionando el residuo vía query param.
+- El tab "Solicitar" arranca el flujo en `/solicitar` (cámara); el catálogo queda como rama alterna.
+- La foto capturada viaja entre pantallas vía `SolicitudFlowProvider` (en memoria).
 - `MisSolicitudes` muestra el nombre del residuo (el GET incluye la relación `residuoCatalogo`).
+
+### Flujo "Solicitar retiro" con IA (esqueleto)
+
+```
+📷 /solicitar → /solicitar/analizando → /solicitar/sugerencias
+                                              ├─ sugerencia → /nueva-solicitud?residuo=ID
+                                              └─ manual     → /nueva-solicitud
+                                                                    ↓ POST (backend)
+                                                          /solicitud/creada
+                                                              ├─ Retiro municipal (placeholder)
+                                                              ├─ Subir a Marketplace (placeholder)
+                                                              └─ Ver mis solicitudes
+```
+
+> La cámara, el análisis IA y las pantallas post-creación son **estáticos**; lo único que
+> pega al backend es el catálogo y la creación/listado de solicitudes (EP-01).
 
 ### Inicio como hub dirigido por configuración (`src/config/modulos.ts`)
 
@@ -187,13 +248,15 @@ npm run lint      # ESLint
 ## Verificación (flujo end-to-end EP-01)
 
 1. Backend OK (`GET /health` → `{"status":"ok","db":"connected"}`).
-2. Abrir `http://localhost:5173` → "Entrar como vecino (dev)".
-3. Caer en **Inicio**: tarjetas activas (Solicitar retiro, Mis solicitudes) +
-   "Próximamente" (Marketplace, Mis créditos, Panel municipal).
-4. Entrar a "Solicitar retiro" → el catálogo muestra los ítems seed
-   (Sofá, Refrigerador, Colchón, Escombros).
-5. Crear una solicitud → redirige a "Mis solicitudes".
-6. La solicitud aparece en estado `pendiente` con el nombre del residuo.
+2. Abrir `http://localhost:5173` → "Entrar como vecino (dev)" o "Ingresar con ClaveÚnica".
+3. Caer en **Inicio**: tarjeta de impacto (demo) + grid de módulos.
+4. Tab **Solicitar** (📷) → captura → "Analizar con IA" → pantalla de análisis →
+   resultado con la detección mock sobre el catálogo real.
+5. Elegir "Usar sugerencia" o "Ingresar manualmente" → el select lista los ítems seed
+   (Sofá, Refrigerador, Colchón, Escombros) con su precio referencial.
+6. Crear la solicitud → `/solicitud/creada` (SuccessRing + CTAs).
+7. **Mis solicitudes** muestra la solicitud en estado `pendiente` con el nombre del residuo
+   (leído desde `GET /solicitudes-retiro`).
 
 ---
 
@@ -202,10 +265,12 @@ npm run lint      # ESLint
 Alineado al roadmap del `README.md`. Cada paso depende de que el backend exponga primero
 los endpoints correspondientes.
 
+> Detalle completo en [`PLAN_FRONTEND.md`](./PLAN_FRONTEND.md).
+
 | Área | Notas |
 |---|---|
-| Aplicar **UI Kit oficial** | Colores/tipografía/íconos de `UI_KIT_ARCA.md`; decidir Tailwind v3 vs v4 |
-| Completar EP-01 | Subida de foto + GPS (campos ya soportados por el DTO), clasificación IA con **TensorFlow.js** (apoyo, el usuario confirma) |
+| Precio/ícono reales | Agregar columnas al backend y quitar el overlay de `arca.ts` |
+| Completar EP-01 | Cámara en vivo (`getUserMedia`), GPS, clasificación IA con **TensorFlow.js** reemplazando el mock |
 | PWA | Service Worker (Workbox) + manifest para modo offline |
 | Auth real (EP-05) | Reemplazar login temporal por JWT/ClaveÚnica en `SessionContext` |
 | Redux Toolkit + RTK Query | Cuando crezca el estado (marketplace, credits, sesión) |
@@ -218,8 +283,8 @@ los endpoints correspondientes.
 
 ## Documentación relacionada
 
+- [`PLAN_FRONTEND.md`](./PLAN_FRONTEND.md) — Sistema de diseño + roadmap por fases del frontend
 - [`SETUP_LOCAL.md`](./SETUP_LOCAL.md) — Cómo levantar el entorno completo
 - [`BACKEND_FASE1.md`](./BACKEND_FASE1.md) — Qué expone el backend hoy
 - [`../README.md`](../README.md) — Producto, stack y roadmap
-- `UI_KIT_ARCA.md` — Sistema de diseño a aplicar (referenciado por el equipo; aún no está en el repo, ver Drive)
 - [`../CLAUDE_proyecto.md`](../CLAUDE_proyecto.md) — Contexto general del proyecto

--- a/docs/FRONTEND_FASE1.md
+++ b/docs/FRONTEND_FASE1.md
@@ -276,7 +276,9 @@ los endpoints correspondientes.
 | Redux Toolkit + RTK Query | Cuando crezca el estado (marketplace, credits, sesión) |
 | EP-02 Marketplace | Listado/publicación, chat en tiempo real (`socket.io-client`), ratings |
 | EP-04 Circular Credits | Saldo + historial en perfil |
-| EP-03 Dashboard municipal | Panel funcionario, mapa de calor (**Leaflet** + OpenStreetMap), reportes |
+| EP-03 Dashboard municipal | ✅ Base hecha (`/admin`: listar/filtrar/detalle + estados, rama `admin-municipal`). Falta panel funcionario completo, mapa de calor (**Leaflet** + OpenStreetMap), reportes |
+| Inicio diferido | ✅ Hecho (`/`): selector App ciudadana / Portal admin |
+| Proteger `/admin` | Pendiente: el panel está abierto hasta que existan guards/JWT |
 | Tests | Vitest + React Testing Library |
 
 ---

--- a/docs/PLAN_FRONTEND.md
+++ b/docs/PLAN_FRONTEND.md
@@ -39,7 +39,9 @@ Clases utilitarias listas: `.card`, `.btn-primary`, `.btn-gold`, `.btn-outline`,
 
 | Pantalla | Ruta | Estado | Datos |
 |---|---|---|---|
+| Inicio diferido | `/` | ✅ **backend** | Selector de portal: App ciudadana / Portal admin |
 | Login | `/login` | ✅ Estética prototipo | CTA ClaveÚnica es mock (login dev) |
+| Panel admin | `/admin` | ✅ **backend** | Listar/filtrar/detalle + modificar estado (EP-03 base) |
 | Inicio / Dashboard | `/inicio` | ✅ | Tarjeta de créditos/impacto **estática** (demo, falta EP-04) |
 | Captura residuo | `/solicitar` | ✅ esqueleto | Cámara/galería **solo visual** (no obligatoria) |
 | Analizando IA | `/solicitar/analizando` | ✅ esqueleto | Scan animado mock (~2.2s) |
@@ -96,8 +98,11 @@ Clases utilitarias listas: `.card`, `.btn-primary`, `.btn-gold`, `.btn-outline`,
 
 ### Fase 6 — Panel Municipal (desktop · EP-03)
 > App separada / layout desktop: `Sidebar + Topbar`.
+- [x] **Inicio diferido** (`/`): selector App ciudadana / Portal admin (rama `admin-municipal`).
+- [x] **Gestión de solicitudes base** (`/admin`): listar, filtrar por estado, detalle y
+      modificar estado (asignar → en ruta → completar → cancelar). Falta layout desktop pulido.
 - [ ] Dashboard: `KPISummary`, `BarChart`/`LineChart`, `MetricsBar`.
-- [ ] Gestión de solicitudes: `FilterBar` + `SideList` + tabla.
+- [ ] Gestión de solicitudes: `FilterBar` + `SideList` + tabla (versión completa).
 - [ ] Mapa de operaciones: Leaflet (`MapContainer`, `PinCluster`, `RoutePolyline`).
 - [ ] Moderación marketplace: grid + `UserFlag` + botones Aprobar/Rechazar.
 - [ ] Reportes: `DateRangePicker` + export PDF/CSV.

--- a/docs/PLAN_FRONTEND.md
+++ b/docs/PLAN_FRONTEND.md
@@ -1,0 +1,116 @@
+# 🎨 Plan de Desarrollo Frontend — A.R.C.A.
+
+> Meta visual: replicar los standalone de referencia (`ARCA UI Kit v1.0` y `ARCA Prototipo`)
+> usando React 18 + Tailwind como PWA mobile-first. Documento vivo: marcar items al integrar.
+
+---
+
+## 🧱 Sistema de diseño (base — ✅ implementado)
+
+Tokens espejados del UI Kit en [`tailwind.config.js`](../apps/frontend/tailwind.config.js) y
+clases reutilizables en [`index.css`](../apps/frontend/src/index.css).
+
+| Token | Valor | Uso |
+|---|---|---|
+| **Tipografía** | Bricolage Grotesque (display) · Hanken Grotesk (body) | títulos / cuerpo |
+| **Verde** | `green-50…900` (primario `700 #0F6B45`) | marca, CTA primario |
+| **Dorado** | `gold-50…600` (`500 #ef9d24`) | Circular Credits, CTA reutilizar |
+| **Rose / Sky** | alertas / info | pills de estado |
+| **Neutros** | `ink`, `slate`, `line`, `canvas #f3f6f3` | texto y superficies |
+| **Radios** | `sm 12 · md 18 · lg 24 · xl 30 · pill` | cards, botones |
+| **Sombras** | `sm/md/lg` + `green`/`gold` (glow) | elevación, botones |
+
+Clases utilitarias listas: `.card`, `.btn-primary`, `.btn-gold`, `.btn-outline`,
+`.btn-ghost`, `.pill`, `.field`, `.chip` / `.chip-active`.
+
+---
+
+## 📐 Shell de la app (✅ implementado)
+
+- Columna mobile centrada (`max-w-md`) sobre canvas — emula el frame del prototipo.
+- Header sticky con marca + Salir.
+- **TabBar inferior** sticky: Inicio · Solicitar (📷) · Solicitudes.
+- Login con hero verde degradado + CTA dorado ClaveÚnica.
+- Estado efímero del flujo (foto capturada) en `flow/SolicitudFlow.tsx`.
+
+---
+
+## ✅ Estado del flujo actual (re-estilizado + conectado al backend)
+
+| Pantalla | Ruta | Estado | Datos |
+|---|---|---|---|
+| Login | `/login` | ✅ Estética prototipo | CTA ClaveÚnica es mock (login dev) |
+| Inicio / Dashboard | `/inicio` | ✅ | Tarjeta de créditos/impacto **estática** (demo, falta EP-04) |
+| Captura residuo | `/solicitar` | ✅ esqueleto | Cámara/galería **solo visual** (no obligatoria) |
+| Analizando IA | `/solicitar/analizando` | ✅ esqueleto | Scan animado mock (~2.2s) |
+| Resultado IA | `/solicitar/sugerencias` | ✅ esqueleto | Detección mock sobre **catálogo real** |
+| Catálogo | `/catalogo` | ✅ **backend** | `GET /residuos/catalogo` + búsqueda/chips |
+| Nueva solicitud | `/nueva-solicitud` | ✅ **backend** | `POST /solicitudes-retiro` |
+| Solicitud creada | `/solicitud/creada` | ✅ esqueleto | SuccessRing + 2 CTAs (retiro / marketplace) |
+| Mis solicitudes | `/mis-solicitudes` | ✅ **backend** | `GET /solicitudes-retiro?usuarioCiudadanoId=` |
+| Retiro municipal | `/retiro-municipal` | ✅ placeholder | "Próximamente" (EP-03) |
+| Subir a Marketplace | `/marketplace/subir` | ✅ placeholder | "Próximamente" (EP-02) |
+
+> **Precio e ícono son overlay del front** (mapeados por categoría en `api/arca.ts`):
+> el backend no expone esas columnas todavía. Migrar a campos reales cuando existan.
+
+---
+
+## 🗺️ Roadmap por fases
+
+### Fase 1 — Pulido del MVP ciudadano (en curso)
+- [x] Sistema de diseño + shell + tab bar.
+- [x] Re-estilizar las pantallas existentes.
+- [x] Reconectar todas las pantallas a los endpoints reales del backend (EP-01).
+- [ ] **Componetizar** primitivos en `src/components/ui/` (Button, Card, Pill, Field, Chip, SearchBar) — hoy son clases CSS; extraer a componentes tipados.
+- [ ] **Detalle / Tracking de retiro** con Timeline de 4 pasos (UI Kit: `Timeline + PulseRing`). Ruta `/solicitud/:id`.
+- [ ] Conectar la tarjeta de créditos/impacto del Inicio a datos reales (EP-04) — hoy es estática.
+- [ ] **Precio e ícono reales:** agregar columnas al backend y quitar el overlay de `api/arca.ts`.
+- [ ] Estados de carga con `Spinner` / skeletons y manejo de error consistente.
+- [ ] Iconografía: migrar emojis → `lucide-react` (acordado en `config/modulos.ts`).
+
+### Fase 2 — Solicitud con IA (EP-01 ampliado)
+- [x] **Esqueleto del flujo** captura → análisis → resultado → éxito (estático).
+- [ ] Cámara en vivo (`getUserMedia`) en vez de `input file` — hoy solo visual.
+- [ ] Clasificación local con TensorFlow.js → reemplaza la detección mock.
+- [ ] Confirmación con foto, GPS aproximado y nota (campos ya soportados por el DTO).
+- [ ] "+5 créditos" real al crear (depende de EP-04).
+- [ ] Pantallas reales de "Retiro municipal" y "Subir al Marketplace" (hoy placeholders).
+
+### Fase 3 — Marketplace P2P (EP-02)
+- [ ] Listado: vista Grid 2 col + vista Lista, con `SearchBar` y chips Regalo/Intercambio/Categorías.
+- [ ] `ArticleCard` + `StatePill` + `HeartBtn` + distancia.
+- [ ] Detalle de artículo: galería, `ModalidadBadge`, vecino con `RatingBadge`/`ShieldVerified`.
+- [ ] Publicar: foto + título + chips categoría + modalidad.
+- [ ] CTA Gold “¿Aún sirve? Regálalo”.
+
+### Fase 4 — Chat entre vecinos (EP-02)
+- [ ] `ChatInput` + burbujas (propias verde / ajenas blanco) + `ReservaBanner` gold.
+- [ ] Integrar Socket.io-client (gateways NestJS).
+
+### Fase 5 — Perfil & Impacto (EP-04)
+- [ ] `ProfileHeader` verde + avatar.
+- [ ] `BalanceCard` Circular Credits + `ImpactCard` (CO₂, litros, barra de hito).
+- [ ] Historial `TransactionRow`, ranking `TrophyRanking`, `SettingRows`.
+- [ ] Añadir 4ª pestaña **Perfil** a la TabBar.
+
+### Fase 6 — Panel Municipal (desktop · EP-03)
+> App separada / layout desktop: `Sidebar + Topbar`.
+- [ ] Dashboard: `KPISummary`, `BarChart`/`LineChart`, `MetricsBar`.
+- [ ] Gestión de solicitudes: `FilterBar` + `SideList` + tabla.
+- [ ] Mapa de operaciones: Leaflet (`MapContainer`, `PinCluster`, `RoutePolyline`).
+- [ ] Moderación marketplace: grid + `UserFlag` + botones Aprobar/Rechazar.
+- [ ] Reportes: `DateRangePicker` + export PDF/CSV.
+
+---
+
+## 🔧 Deuda técnica / infraestructura
+- [ ] Estado global: migrar fetch manual → **Redux Toolkit + RTK Query** (roadmap B.3).
+- [ ] Auth real: ClaveÚnica (OAuth2) + JWT, reemplazar `SessionContext` mock.
+- [ ] PWA: manifest + service worker (offline catálogo).
+- [ ] Tests de UI (Vitest + Testing Library) por componente.
+- [ ] `docs/UI_KIT.md`: documentar tokens y componentes con referencias al standalone.
+
+---
+
+**Última actualización:** 2026-06-24 · Equipo COM Tech

--- a/docs/PLAN_FRONTEND.md
+++ b/docs/PLAN_FRONTEND.md
@@ -39,9 +39,10 @@ Clases utilitarias listas: `.card`, `.btn-primary`, `.btn-gold`, `.btn-outline`,
 
 | Pantalla | Ruta | Estado | Datos |
 |---|---|---|---|
-| Inicio diferido | `/` | ✅ **backend** | Selector de portal: App ciudadana / Portal admin |
-| Login | `/login` | ✅ Estética prototipo | CTA ClaveÚnica es mock (login dev) |
-| Panel admin | `/admin` | ✅ **backend** | Listar/filtrar/detalle + modificar estado (EP-03 base) |
+| Login (ClaveÚnica) | `/login` | ✅ **backend** | Primera vista. Mock: accesos dev Vecino / Funcionario |
+| Gate login diferido | `/` | ✅ **backend** | Funcionario → selección; solo ciudadano → `/inicio` |
+| Selección de contexto | `/` (admin) | ✅ **backend** | Solo funcionarios: App ciudadana / Panel municipal |
+| Panel admin | `/admin` | ✅ **backend** | `RequireAdmin`. Listar/filtrar/detalle + estado **reversible** (EP-03 base) |
 | Inicio / Dashboard | `/inicio` | ✅ | Tarjeta de créditos/impacto **estática** (demo, falta EP-04) |
 | Captura residuo | `/solicitar` | ✅ esqueleto | Cámara/galería **solo visual** (no obligatoria) |
 | Analizando IA | `/solicitar/analizando` | ✅ esqueleto | Scan animado mock (~2.2s) |
@@ -49,7 +50,7 @@ Clases utilitarias listas: `.card`, `.btn-primary`, `.btn-gold`, `.btn-outline`,
 | Catálogo | `/catalogo` | ✅ **backend** | `GET /residuos/catalogo` + búsqueda/chips |
 | Nueva solicitud | `/nueva-solicitud` | ✅ **backend** | `POST /solicitudes-retiro` |
 | Solicitud creada | `/solicitud/creada` | ✅ esqueleto | SuccessRing + 2 CTAs (retiro / marketplace) |
-| Mis solicitudes | `/mis-solicitudes` | ✅ **backend** | `GET /solicitudes-retiro?usuarioCiudadanoId=` |
+| Mis solicitudes | `/mis-solicitudes` | ✅ **backend** | Lista → detalle (descripción) + cancelar; oculta local |
 | Retiro municipal | `/retiro-municipal` | ✅ placeholder | "Próximamente" (EP-03) |
 | Subir a Marketplace | `/marketplace/subir` | ✅ placeholder | "Próximamente" (EP-02) |
 
@@ -98,9 +99,10 @@ Clases utilitarias listas: `.card`, `.btn-primary`, `.btn-gold`, `.btn-outline`,
 
 ### Fase 6 — Panel Municipal (desktop · EP-03)
 > App separada / layout desktop: `Sidebar + Topbar`.
-- [x] **Inicio diferido** (`/`): selector App ciudadana / Portal admin (rama `admin-municipal`).
+- [x] **Login diferido** (`/login` → gate `/`): ClaveÚnica primero; según `perfil-acceso`
+      el funcionario elige contexto y el ciudadano va directo a la PWA. `/admin` con `RequireAdmin`.
 - [x] **Gestión de solicitudes base** (`/admin`): listar, filtrar por estado, detalle y
-      modificar estado (asignar → en ruta → completar → cancelar). Falta layout desktop pulido.
+      cambiar estado en cualquier dirección (reversible, para pruebas). Falta layout desktop pulido.
 - [ ] Dashboard: `KPISummary`, `BarChart`/`LineChart`, `MetricsBar`.
 - [ ] Gestión de solicitudes: `FilterBar` + `SideList` + tabla (versión completa).
 - [ ] Mapa de operaciones: Leaflet (`MapContainer`, `PinCluster`, `RoutePolyline`).

--- a/docs/SETUP_LOCAL.md
+++ b/docs/SETUP_LOCAL.md
@@ -22,26 +22,22 @@ Opcional:
 
 ---
 
-## 1. Clonar y elegir rama
+## 1. Clonar y ubicarse en develop
 
 ```bash
 git clone https://github.com/blindjamin/A.R.C.A.git
 cd A.R.C.A
 git fetch origin
+git checkout develop
+git pull origin develop
 ```
 
-| Rol | Rama recomendada |
-|---|---|
-| Javier (backend) | `feature/backend` |
-| Maximiliano (frontend) | `feature/frontend` |
-| Benjamín (auth) | `feature/auth` |
-| Ana (dashboard/marketplace) | `feature/dashboard` o `feature/marketplace` |
-| Integración general | `develop` (tras merge de PRs) |
-
-```bash
-git checkout feature/backend   # o tu rama de módulo
-git pull origin feature/backend
-```
+> **Modo de trabajo:** se trabaja sobre `develop` mediante **ramas temporales** por tarea
+> (creadas desde `develop`, borradas al integrar). `master`/`main` solo recibe versiones
+> completas. Detalle en [`../CLAUDE.md`](../CLAUDE.md). Para tu tarea:
+> ```bash
+> git checkout -b <descripción-tarea>   # ej: catalogo-filtros
+> ```
 
 ---
 
@@ -116,15 +112,19 @@ Respuesta health esperada: `{"status":"ok","db":"connected"}`
 
 ### 4.1 Rama y carpeta
 
-Trabajar en `feature/frontend`:
+> **Nota:** la app frontend **ya existe** en `apps/frontend/` (ver [`FRONTEND_FASE1.md`](./FRONTEND_FASE1.md)).
+> Esta sección queda como referencia histórica del scaffold inicial.
+
+Trabajar desde `develop` con una rama temporal:
 
 ```bash
 git fetch origin
-git checkout feature/frontend
-git rebase origin/develop   # o pull de develop cuando esté actualizado
+git checkout develop
+git pull origin develop
+git checkout -b <descripción-tarea>   # ej: frontend-filtros
 ```
 
-Crear la app en el monorepo:
+Scaffold original (solo referencia, ya ejecutado):
 
 ```bash
 cd A.R.C.A
@@ -240,7 +240,7 @@ export async function crearSolicitudRetiro(data: {
 - [ ] Pantalla catálogo consumiendo `GET /residuos/catalogo`
 - [ ] Formulario POST solicitud de retiro
 - [ ] Listado de solicitudes del usuario dev
-- [ ] PR de `feature/frontend` → `develop`
+- [ ] Integrar a `develop` y borrar la rama temporal
 
 ---
 
@@ -249,7 +249,7 @@ export async function crearSolicitudRetiro(data: {
 ### Benjamín (auth)
 
 - Base en `apps/backend/src/users/` (entidades identidad)
-- Rama: `feature/auth`
+- Rama temporal desde `develop` (ej: `auth-jwt`)
 - Backend debe estar corriendo + migraciones aplicadas
 - ClaveÚnica real: pendiente aprobación municipal; puede empezar con JWT mock
 
@@ -325,8 +325,8 @@ No hace falta instalar MySQL ni Nest CLI global; MySQL va en Docker y NestJS viv
 git clone https://github.com/blindjamin/A.R.C.A.git
 cd A.R.C.A
 git fetch origin
-git checkout feature/backend    # o develop, según acuerdo del equipo
-git pull
+git checkout develop
+git pull origin develop
 
 docker compose up -d
 


### PR DESCRIPTION
# 🌿 A.R.C.A. V1 — alpha

> **Primera versión funcional preliminar (alpha).** Es un MVP demostrable de punta a punta
> (ciudadano + panel municipal), pensado para mostrar el producto y seguir iterando. Aún usa
> auth mock (sin ClaveÚnica/JWT real) y datos semilla de desarrollo, por lo que **no es apta
> para producción** todavía. Marca el primer hito completo del proyecto sobre `master`.

---

## Resumen

Integra a `master` el módulo de **gestión municipal de solicitudes de retiro** (EP-01/EP-03 base) junto con el **login diferido** y mejoras del flujo ciudadano. Trabajo realizado en la rama temporal `admin-municipal`, ya integrada en `develop`.

## Qué cambió

### Backend (NestJS + TypeORM)
- **Endpoints admin** de solicitudes: `GET /:id` (detalle), `PATCH /:id` (modificar estado/operador/fecha/razón), filtro `?estado=`.
- **Cancelación por ciudadano**: `PATCH /:id/cancelar` (valida propiedad → `403` si es ajena; solo `pendiente`/`asignada`).
- **Login diferido**: `GET /usuarios/:id/perfil-acceso` → indica si la identidad base tiene extensión de administrador.
- **Cambio de estado libre/reversible** en el panel (avanzar o revertir) para operar/probar; limpia `fechaCompletada` al salir de completada.
- **Migración seed**: usuario demo **doble rol** (ciudadano `…0002` + operador `…00A2`).

### Frontend (React + Vite + Tailwind)
- **Login diferido**: ClaveÚnica como primera vista (`/login`) → gate `/` decide: funcionario → selección de contexto; solo ciudadano → PWA directa. `/admin` protegido con `RequireAdmin`.
- **Panel municipal** (`/admin`): listar, filtrar por estado, detalle y cambiar estado en cualquier dirección.
- **Mis solicitudes** (ciudadano): tocar la solicitud abre el detalle con descripción y opción de cancelar (se oculta de la lista local; solo `pendiente`/`asignada`).

### Docs
- `BACKEND_FASE1.md`, `PLAN_FRONTEND.md`, `FRONTEND_FASE1.md` actualizados (endpoints, login diferido, operador demo, pendientes).

## Notas para revisión
- **Auth mock**: ClaveÚnica/JWT aún no está; los accesos dev (Vecino / Funcionario) y el usuario demo son **solo para desarrollo** (no usar en producción).
- **Máquina de estados relajada a propósito** (reversible) para esta fase. Queda como pendiente endurecerla tras un flag/permiso.
- `/admin` está protegido solo en el front (`RequireAdmin`); falta el guard real en backend cuando entre JWT.
- El "ocultar" de Mis solicitudes es local al navegador (localStorage); persistirlo entre dispositivos requeriría una columna en BD.

## Cómo probar
1. `docker compose up -d` → `npm run migration:run` (en `apps/backend`) → backend y frontend en dev.
2. En http://localhost:5173: **Funcionario (dev)** para el panel admin; **Vecino (dev)** para la PWA.
3. Operador demo para asignar: `00000000-0000-4000-8000-0000000000A2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
